### PR TITLE
FOLIO-3733: Dockerfile: apt upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM folioci/alpine-jre-openjdk17:latest
 
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
+
 # Copy your fat jar to the container
 ENV APP_FILE mod-consortia.jar
 # - should be a single jar file


### PR DESCRIPTION
Running "apk upgrade" is needed because base images like alpine or eclipse-temurin don't publish an upgraded version on hub.docker.com when fixes of dependencies are available. This needs to be done when building the final FOLIO Docker image. This is recommended on https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk17#sample-module-dockerfile and https://dev.folio.org/guides/best-practices-dockerfiles/

After amending the Dockerfile no further code change is needed.