### PR TITLE
MODCON-42. Not create shadow admin and dummy user tenant for central tenant

### DIFF
--- a/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
@@ -119,7 +119,7 @@ public class TenantServiceImpl implements TenantService {
       createPrimaryUserAffiliationsAsync.createPrimaryUserAffiliationsAsync(consortiumId, savedTenantEntity, tenantDto);
       if (!tenantDto.getIsCentral()) {
         createUserTenantWithDummyUser(tenantDto.getId());
-        createShadowAdminUserWithPermissions(shadowAdminUser);
+        createShadowAdminUserWithPermissions(shadowAdminUser); //NOSONAR
       }
     }
     log.info("save:: saved consortia configuration with centralTenantId={} by tenantId={} context", centralTenantId, tenantDto.getId());

--- a/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
@@ -92,7 +92,7 @@ public class TenantServiceImpl implements TenantService {
         tenantDto.getId(), tenantDto.getIsCentral());
     FolioExecutionContext currentTenantContext = (FolioExecutionContext) folioExecutionContext.getInstance();
 
-    // validation consortium and tenant existence
+    // validation part
     checkTenantNotExistsAndConsortiumExistsOrThrow(consortiumId, tenantDto.getId());
     if (tenantDto.getIsCentral()) {
       checkCentralTenantExistsOrThrow();

--- a/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
@@ -48,7 +48,7 @@ public class TenantServiceImpl implements TenantService {
   private static final String TENANTS_IDS_NOT_MATCHED_ERROR_MSG = "Request body tenantId and path param tenantId should be identical";
   private static final String TENANT_HAS_ACTIVE_USER_ASSOCIATIONS_ERROR_MSG = "Cannot delete tenant with ID {tenantId} because it has an association with a user. "
       + "Please remove the user association before attempting to delete the tenant.";
-  private static final String DUMMY_USERNAME = "*-dummy_user-*";
+  private static final String DUMMY_USERNAME = "dummy_user";
   private final TenantRepository tenantRepository;
   private final UserTenantRepository userTenantRepository;
   private final ConversionService converter;
@@ -110,9 +110,11 @@ public class TenantServiceImpl implements TenantService {
 
     try (var context = new FolioExecutionContextSetter(contextHelper.getSystemUserFolioExecutionContext(tenantDto.getId()))) {
       configurationClient.saveConfiguration(createConsortiaConfigurationBody(centralTenantId));
-      createUserTenantWithDummyUser(tenantDto.getId());
-      createShadowAdminUserWithPermissions(shadowAdminUser);
       createPrimaryUserAffiliationsAsync.createPrimaryUserAffiliationsAsync(consortiumId, savedTenantEntity, tenantDto);
+      if (!tenantDto.getIsCentral()) {
+        createUserTenantWithDummyUser(tenantDto.getId());
+        createShadowAdminUserWithPermissions(shadowAdminUser);
+      }
     }
     log.info("save:: saved consortia configuration with centralTenantId={} by tenantId={} context", centralTenantId, tenantDto.getId());
     return savedTenant;

--- a/src/test/java/org/folio/consortia/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantServiceTest.java
@@ -154,6 +154,8 @@ class TenantServiceTest {
 
     var tenant1 = tenantService.save(consortiumId, UUID.randomUUID(), tenant);
 
+    verify(userService).prepareShadowUser(any(), any());
+    verify(userTenantRepository).save(any());
     verify(configurationClient).saveConfiguration(any());
     verify(userAffiliationAsyncService).createPrimaryUserAffiliationsAsync(any(), any(), any());
     verify(userTenantsClient).postUserTenant(any());
@@ -200,6 +202,8 @@ class TenantServiceTest {
     verify(configurationClient).saveConfiguration(any());
     verify(userAffiliationAsyncService).createPrimaryUserAffiliationsAsync(any(), any(), any());
 
+    verify(userService, never()).prepareShadowUser(any(), any());
+    verify(userTenantRepository, never()).save(any());
     verify(userTenantsClient, never()).postUserTenant(any());
     verify(userService, never()).createUser(any());
     verify(permissionUserService, never()).createWithPermissionsFromFile(any(), any());

--- a/src/test/java/org/folio/consortia/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantServiceTest.java
@@ -158,7 +158,6 @@ class TenantServiceTest {
     verify(userAffiliationAsyncService).createPrimaryUserAffiliationsAsync(any(), any(), any());
     verify(userTenantsClient).postUserTenant(any());
     verify(userService).createUser(any());
-    verify(permissionUserService).createWithPermissionsFromFile(any(), any());
 
     Assertions.assertEquals(tenant, tenant1);
   }


### PR DESCRIPTION
## Purpose

- We need to create dummy user tenant record only for non-central tenants
- We need to create shadow admin users only for non-central tenants
- We need to create user_tenant association for shadow admins only for non-central tenants

