### PR TITLE
MODCON-48 removed semaphores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <publish_coordinator.yaml.file>${project.basedir}/src/main/resources/swagger.api/publications.yaml</publish_coordinator.yaml.file>
     <sharing_instances.yaml.file>${project.basedir}/src/main/resources/swagger.api/sharing_instance.yaml</sharing_instances.yaml.file>
     <!-- runtime dependencies -->
-    <folio-spring-base.version>7.1.0</folio-spring-base.version>
+    <folio-spring-base.version>7.1.2</folio-spring-base.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
 

--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -147,7 +147,7 @@ public class PublicationServiceImpl implements PublicationService {
 
     executor.shutdown();
     try {
-      if (executor.awaitTermination(60, TimeUnit.SECONDS)) {
+      if (executor.awaitTermination(300, TimeUnit.SECONDS)) {
         updatePublicationsStatus(futures, createdPublicationEntity, folioExecutionContext);
         executor.shutdownNow();
       }

--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -162,7 +162,7 @@ public class PublicationServiceImpl implements PublicationService {
     PublicationTenantRequestEntity savedPublicationTenantRequest) {
     PublicationTenantRequestEntity updatedPtre;
     try {
-      var response = executeAsyncHttpRequest(publicationRequest, tenantId, folioExecutionContext);
+      var response = executeHttpRequest(publicationRequest, tenantId, folioExecutionContext);
       updatedPtre = updateSucceedPublicationTenantRequest(response, savedPublicationTenantRequest, folioExecutionContext);
     } catch (Exception e) {
       updatedPtre = updateFailedPublicationTenantRequest(e, savedPublicationTenantRequest, folioExecutionContext);
@@ -179,7 +179,7 @@ public class PublicationServiceImpl implements PublicationService {
     }
   }
 
-  ResponseEntity<String> executeAsyncHttpRequest(PublicationRequest publicationRequest, String tenantId, FolioExecutionContext centralTenantContext) {
+  ResponseEntity<String> executeHttpRequest(PublicationRequest publicationRequest, String tenantId, FolioExecutionContext centralTenantContext) {
     try (var context = new FolioExecutionContextSetter(prepareContextForTenant(tenantId, folioModuleMetadata, centralTenantContext))) {
       var response = httpRequestService.performRequest(publicationRequest.getUrl(), HttpMethod.POST, publicationRequest.getPayload());
       if (response.getStatusCode().is2xxSuccessful()) {

--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -183,15 +183,15 @@ public class PublicationServiceImpl implements PublicationService {
     try (var context = new FolioExecutionContextSetter(prepareContextForTenant(tenantId, folioModuleMetadata, centralTenantContext))) {
       var response = httpRequestService.performRequest(publicationRequest.getUrl(), HttpMethod.POST, publicationRequest.getPayload());
       if (response.getStatusCode().is2xxSuccessful()) {
-        log.info("executeAsyncTask:: successfully called {} on tenant {}", publicationRequest.getUrl(), tenantId);
+        log.info("executeHttpRequest:: successfully called {} on tenant {}", publicationRequest.getUrl(), tenantId);
       } else {
         var errMessage = response.getBody() != null ? response.getBody() : "Generic Error";
-        log.error("executeAsyncTask:: error making {} '{}' request on tenant {}", publicationRequest.getMethod(), publicationRequest.getUrl(), tenantId, new HttpException(errMessage));
+        log.error("executeHttpRequest:: error making {} '{}' request on tenant {}", publicationRequest.getMethod(), publicationRequest.getUrl(), tenantId, new HttpException(errMessage));
         throw new HttpClientErrorException(response.getStatusCode(), errMessage);
       }
       return response;
     } catch (HttpClientErrorException e) {
-      log.error("executeAsyncTask:: error making {} '{}' request on tenant {}", publicationRequest.getMethod(), publicationRequest.getUrl(), tenantId, new HttpException(e.getMessage()));
+      log.error("executeHttpRequest:: error making {} '{}' request on tenant {}", publicationRequest.getMethod(), publicationRequest.getUrl(), tenantId, e);
       throw new HttpClientErrorException(e.getStatusCode(), e.getMessage());
     }
   }

--- a/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
+++ b/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
@@ -80,40 +80,6 @@ class PublicationServiceImplTest extends BaseUnitTest {
     var response = publicationService.executeAsyncHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext);
     Assertions.assertEquals(payload, response.getBody());
   }
-  @Test
-  void executeAsyncHttpWithErrorResponse() throws JsonProcessingException {
-    var pr = getMockDataObject(PUBLICATION_REQUEST_SAMPLE, PublicationRequest.class);
-    var payload = objectMapper.writeValueAsString(pr.getPayload());
-    var publicationStatusEntity = getMockDataObject(PUBLICATION_STATUS_ENTITY_SAMPLE, PublicationStatusEntity.class);
-    publicationStatusEntity.setCreatedDate(LocalDateTime.now());
-
-    when(objectMapper.writeValueAsString(anyString())).thenReturn(RandomStringUtils.random(10));
-    when(publicationTenantRequestRepository.save(any(PublicationTenantRequestEntity.class))).thenReturn(new PublicationTenantRequestEntity());
-
-    ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(301));
-    when(httpRequestService.performRequest(anyString(), eq(HttpMethod.POST), any())).thenReturn(restTemplateResponse);
-
-    var future = publicationService.executeAsyncHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext);
-
-    assertThrowsCause(HttpClientErrorException.class, future::join);
-  }
-
-  @Test
-  void executeAsyncHttpFailure() throws JsonProcessingException {
-    var pr = getMockDataObject(PUBLICATION_REQUEST_SAMPLE, PublicationRequest.class);
-    var publicationStatusEntity = getMockDataObject(PUBLICATION_STATUS_ENTITY_SAMPLE, PublicationStatusEntity.class);
-    publicationStatusEntity.setCreatedDate(LocalDateTime.now());
-
-    when(objectMapper.writeValueAsString(anyString())).thenReturn(RandomStringUtils.random(10));
-    when(publicationTenantRequestRepository.save(any(PublicationTenantRequestEntity.class))).thenReturn(new PublicationTenantRequestEntity());
-
-    when(httpRequestService.performRequest(anyString(), eq(HttpMethod.POST), any()))
-      .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase()));
-
-    var future = publicationService.executeAsyncHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext);
-
-    assertThrowsCause(HttpClientErrorException.class, future::join);
-  }
 
 
   @Test
@@ -126,7 +92,7 @@ class PublicationServiceImplTest extends BaseUnitTest {
     var payload = RandomStringUtils.random(10);
     ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(201));
 
-    publicationService.updatePublicationTenantRequest(restTemplateResponse, null, ptrEntity, folioExecutionContext);
+    publicationService.updateSucceedPublicationTenantRequest(restTemplateResponse, ptrEntity, folioExecutionContext);
     verify(publicationTenantRequestRepository).save(ptreCaptor.capture());
 
     var capturedPtre = ptreCaptor.getValue();
@@ -142,7 +108,7 @@ class PublicationServiceImplTest extends BaseUnitTest {
     when(publicationTenantRequestRepository.save(any(PublicationTenantRequestEntity.class))).thenReturn(new PublicationTenantRequestEntity());
 
     Throwable t = new CompletionException(new HttpClientErrorException(HttpStatusCode.valueOf(400), HttpStatus.BAD_REQUEST.getReasonPhrase()));
-    publicationService.updatePublicationTenantRequest(null, t, ptrEntity, folioExecutionContext);
+    publicationService.updateFailedPublicationTenantRequest(t, ptrEntity, folioExecutionContext);
     verify(publicationTenantRequestRepository).save(ptreCaptor.capture());
 
     var capturedPtre = ptreCaptor.getValue();

--- a/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
+++ b/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
@@ -77,7 +77,7 @@ class PublicationServiceImplTest extends BaseUnitTest {
 
     ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(201));
     when(httpRequestService.performRequest(anyString(), eq(HttpMethod.POST), any())).thenReturn(restTemplateResponse);
-    var response = publicationService.executeAsyncHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext).join();
+    var response = publicationService.executeAsyncHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext);
     Assertions.assertEquals(payload, response.getBody());
   }
   @Test

--- a/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
+++ b/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
@@ -79,7 +79,7 @@ class PublicationServiceImplTest extends BaseUnitTest {
 
     ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(201));
     when(httpRequestService.performRequest(anyString(), eq(HttpMethod.POST), any())).thenReturn(restTemplateResponse);
-    var response = publicationService.executeAsyncHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext);
+    var response = publicationService.executeHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext);
     Assertions.assertEquals(payload, response.getBody());
   }
   @Test
@@ -92,7 +92,7 @@ class PublicationServiceImplTest extends BaseUnitTest {
     ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(301));
     when(httpRequestService.performRequest(anyString(), eq(HttpMethod.POST), any())).thenReturn(restTemplateResponse);
 
-    assertThrows(HttpClientErrorException.class, () -> publicationService.executeAsyncHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext));
+    assertThrows(HttpClientErrorException.class, () -> publicationService.executeHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext));
   }
 
   @Test
@@ -104,7 +104,7 @@ class PublicationServiceImplTest extends BaseUnitTest {
     doThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase()))
       .when(httpRequestService).performRequest(anyString(), eq(HttpMethod.POST), any());
 
-    assertThrows(HttpClientErrorException.class, () -> publicationService.executeAsyncHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext));
+    assertThrows(HttpClientErrorException.class, () -> publicationService.executeHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext));
   }
 
 


### PR DESCRIPTION
## Purpose
* combining semaphores, fork join pool and task executor may produce threads execution issues

## Approach
* switched from semafores to fixed tread pool

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
