### PR TITLE
MODCON-48 fixed status code

### DIFF
--- a/src/main/java/org/folio/consortia/controller/PublicationController.java
+++ b/src/main/java/org/folio/consortia/controller/PublicationController.java
@@ -1,8 +1,8 @@
 package org.folio.consortia.controller;
 
-import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
+import java.net.URI;
 import java.util.UUID;
 
 import org.folio.consortia.domain.dto.PublicationDetailsResponse;
@@ -25,7 +25,8 @@ public class PublicationController implements org.folio.consortia.rest.resource.
 
   @Override
   public ResponseEntity<PublicationResponse> publishRequests(UUID consortiumId, PublicationRequest publicationRequest) {
-    return ResponseEntity.status(CREATED).body(publishCoordinatorService.publishRequest(consortiumId, publicationRequest));
+    PublicationResponse response = publishCoordinatorService.publishRequest(consortiumId, publicationRequest);
+    return ResponseEntity.created(URI.create("/publications/" + response.getId())).body(response);
   }
 
   @Override

--- a/src/main/java/org/folio/consortia/controller/PublicationController.java
+++ b/src/main/java/org/folio/consortia/controller/PublicationController.java
@@ -1,5 +1,6 @@
 package org.folio.consortia.controller;
 
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import java.util.UUID;
@@ -24,7 +25,7 @@ public class PublicationController implements org.folio.consortia.rest.resource.
 
   @Override
   public ResponseEntity<PublicationResponse> publishRequests(UUID consortiumId, PublicationRequest publicationRequest) {
-    return ResponseEntity.ok(publishCoordinatorService.publishRequest(consortiumId, publicationRequest));
+    return ResponseEntity.status(CREATED).body(publishCoordinatorService.publishRequest(consortiumId, publicationRequest));
   }
 
   @Override

--- a/src/main/java/org/folio/consortia/domain/dto/PublicationHttpResponse.java
+++ b/src/main/java/org/folio/consortia/domain/dto/PublicationHttpResponse.java
@@ -1,0 +1,15 @@
+package org.folio.consortia.domain.dto;
+
+import org.springframework.http.HttpStatusCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PublicationHttpResponse {
+  private String body;
+  private HttpStatusCode statusCode;
+}

--- a/src/main/java/org/folio/consortia/service/HttpRequestService.java
+++ b/src/main/java/org/folio/consortia/service/HttpRequestService.java
@@ -1,8 +1,8 @@
 package org.folio.consortia.service;
 
+import org.folio.consortia.domain.dto.PublicationHttpResponse;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 
 public interface HttpRequestService {
-  ResponseEntity<String> performRequest(String url, HttpMethod httpMethod, Object payload);
+  PublicationHttpResponse performRequest(String url, HttpMethod httpMethod, Object payload);
 }

--- a/src/main/java/org/folio/consortia/service/HttpRequestServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/HttpRequestServiceImpl.java
@@ -4,16 +4,19 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.folio.consortia.domain.dto.PublicationHttpResponse;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 
 @Service
@@ -22,14 +25,19 @@ import lombok.extern.log4j.Log4j2;
 public class HttpRequestServiceImpl implements HttpRequestService {
   private final RestTemplate restTemplate;
   private final FolioExecutionContext folioExecutionContext;
+  private final ObjectMapper objectMapper;
 
+  @SneakyThrows
   @Override
-  public ResponseEntity<String> performRequest(String url, HttpMethod httpMethod, Object payload) {
+  public PublicationHttpResponse performRequest(String url, HttpMethod httpMethod, Object payload) {
     var headers = convertHeadersToMultiMap(folioExecutionContext.getAllHeaders());
     HttpEntity<Object> httpEntity = new HttpEntity<>(payload, headers);
     var absUrl = folioExecutionContext.getOkapiUrl() + url;
     log.debug("performRequest:: folio context header TENANT = {}" , folioExecutionContext.getOkapiHeaders().get(XOkapiHeaders.TENANT).iterator().next());
-    return restTemplate.exchange(absUrl, httpMethod, httpEntity, String.class);
+
+    var responseEntity = restTemplate.exchange(absUrl, httpMethod, httpEntity, Object.class);
+
+    return new PublicationHttpResponse(objectMapper.writeValueAsString(responseEntity.getBody()), responseEntity.getStatusCode());
   }
 
   private HttpHeaders convertHeadersToMultiMap(Map<String, Collection<String>> contextHeaders) {

--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.http.HttpException;
 import org.folio.consortia.domain.dto.PublicationDetailsResponse;
+import org.folio.consortia.domain.dto.PublicationHttpResponse;
 import org.folio.consortia.domain.dto.PublicationRequest;
 import org.folio.consortia.domain.dto.PublicationResponse;
 import org.folio.consortia.domain.dto.PublicationResult;
@@ -45,7 +46,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
@@ -183,7 +183,7 @@ public class PublicationServiceImpl implements PublicationService {
     }
   }
 
-  ResponseEntity<String> executeHttpRequest(PublicationRequest publicationRequest, String tenantId, FolioExecutionContext centralTenantContext) {
+  PublicationHttpResponse executeHttpRequest(PublicationRequest publicationRequest, String tenantId, FolioExecutionContext centralTenantContext) {
     try (var context = new FolioExecutionContextSetter(prepareContextForTenant(tenantId, folioModuleMetadata, centralTenantContext))) {
       var response = httpRequestService.performRequest(publicationRequest.getUrl(), HttpMethod.valueOf(publicationRequest.getMethod()), publicationRequest.getPayload());
       if (response.getStatusCode().is2xxSuccessful()) {
@@ -200,7 +200,7 @@ public class PublicationServiceImpl implements PublicationService {
     }
   }
 
-  PublicationTenantRequestEntity updateSucceedPublicationTenantRequest(ResponseEntity<String> responseEntity, PublicationTenantRequestEntity ptrEntity, FolioExecutionContext centralTenantContext) {
+  PublicationTenantRequestEntity updateSucceedPublicationTenantRequest(PublicationHttpResponse responseEntity, PublicationTenantRequestEntity ptrEntity, FolioExecutionContext centralTenantContext) {
     var currentLocalDateTime = LocalDateTime.now();
     ptrEntity.setCompletedDate(currentLocalDateTime);
 

--- a/src/test/java/org/folio/consortia/controller/PublicationControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/PublicationControllerTest.java
@@ -215,7 +215,7 @@ public class PublicationControllerTest extends BaseIT {
     this.mockMvc.perform(delete(url).headers(headers))
       .andExpect(status().isNoContent());
   }
-  
+
   @ParameterizedTest
   @CsvSource(value = {"100, 12"})
   void parallelTenantRequestsTest(int tenantsAmount, int chunkSize) throws JsonProcessingException {
@@ -243,10 +243,10 @@ public class PublicationControllerTest extends BaseIT {
       .map(val -> "tenant_" + val)
       .toList();
 
-    ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(ptreAsString, HttpStatusCode.valueOf(201));
+    ResponseEntity<Object> restTemplateResponse = new ResponseEntity<>(ptreAsString, HttpStatusCode.valueOf(201));
 
     ArgumentCaptor<HttpEntity<Object>> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
-    when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), entityCaptor.capture(), eq(String.class))).thenReturn(restTemplateResponse);
+    when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), entityCaptor.capture(), eq(Object.class))).thenReturn(restTemplateResponse);
 
     // split list of tenants into chunks and make parallel API calls
     StreamEx.ofSubLists(listOfTenantNames, chunkSize)
@@ -277,7 +277,7 @@ public class PublicationControllerTest extends BaseIT {
       .sorted()
       .toList();
 
-    verify(restTemplate, times(listOfTenantNames.size())).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class));
+    verify(restTemplate, times(listOfTenantNames.size())).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Object.class));
     // check if all 'x-okapi-tenant' values match with the initial list of expected tenant names
     Assertions.assertTrue(CollectionUtils.isEqualCollection(capturedTenantHeaders, listOfTenantNames));
   }

--- a/src/test/java/org/folio/consortia/service/HttpRequestServiceImplTest.java
+++ b/src/test/java/org/folio/consortia/service/HttpRequestServiceImplTest.java
@@ -1,5 +1,6 @@
 package org.folio.consortia.service;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -17,6 +18,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 
 class HttpRequestServiceImplTest extends BaseUnitTest {
 
@@ -24,10 +28,13 @@ class HttpRequestServiceImplTest extends BaseUnitTest {
   HttpRequestServiceImpl httpRequestService;
   @Mock
   RestTemplate restTemplate;
+  @Mock
+  ObjectMapper objectMapper;
   @Test
-  void performRequestSuccess() {
-    var payload = RandomStringUtils.random(10);
-    ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(201));
+  void performRequestSuccess() throws JsonProcessingException {
+    Object payload = RandomStringUtils.random(10);
+
+    ResponseEntity<Object> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(201));
     when(folioExecutionContext.getTenantId()).thenReturn(CENTRAL_TENANT_NAME);
     when(folioExecutionContext.getOkapiHeaders()).thenReturn(defaultHeaders());
     when(folioExecutionContext.getAllHeaders()).thenReturn(defaultHeaders());
@@ -35,10 +42,11 @@ class HttpRequestServiceImplTest extends BaseUnitTest {
       anyString(),
       eq(HttpMethod.POST),
       Mockito.any(HttpEntity.class),
-      Mockito.eq(String.class))
+      Mockito.eq(Object.class))
     ).thenReturn(restTemplateResponse);
+    when(objectMapper.writeValueAsString(any())).thenReturn((String) payload);
 
-    var response = httpRequestService.performRequest(payload, HttpMethod.POST, new Object());
+    var response = httpRequestService.performRequest(RandomStringUtils.random(10), HttpMethod.POST, new Object());
     Assertions.assertEquals(payload, response.getBody());
   }
 }

--- a/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
+++ b/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 
+import org.folio.consortia.domain.dto.PublicationHttpResponse;
 import org.folio.consortia.domain.dto.PublicationRequest;
 import org.folio.consortia.domain.dto.PublicationStatus;
 import org.folio.consortia.domain.entity.PublicationStatusEntity;
@@ -35,7 +36,6 @@ import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
@@ -87,7 +87,7 @@ class PublicationServiceImplTest extends BaseUnitTest {
     when(objectMapper.writeValueAsString(anyString())).thenReturn(RandomStringUtils.random(10));
     when(publicationTenantRequestRepository.save(any(PublicationTenantRequestEntity.class))).thenReturn(new PublicationTenantRequestEntity());
 
-    ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(201));
+    var restTemplateResponse = new PublicationHttpResponse(payload, HttpStatusCode.valueOf(201));
     when(httpRequestService.performRequest(anyString(), eq(HttpMethod.POST), any())).thenReturn(restTemplateResponse);
     var response = publicationService.executeHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext);
     Assertions.assertEquals(payload, response.getBody());
@@ -99,7 +99,7 @@ class PublicationServiceImplTest extends BaseUnitTest {
     var publicationStatusEntity = getMockDataObject(PUBLICATION_STATUS_ENTITY_SAMPLE, PublicationStatusEntity.class);
     publicationStatusEntity.setCreatedDate(LocalDateTime.now());
 
-    ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(301));
+    var restTemplateResponse = new PublicationHttpResponse(payload, HttpStatusCode.valueOf(301));
     when(httpRequestService.performRequest(anyString(), eq(HttpMethod.POST), any())).thenReturn(restTemplateResponse);
 
     assertThrows(HttpClientErrorException.class, () -> publicationService.executeHttpRequest(pr, CENTRAL_TENANT_NAME, folioExecutionContext));
@@ -126,7 +126,7 @@ class PublicationServiceImplTest extends BaseUnitTest {
     when(publicationStatusRepository.save(any(PublicationStatusEntity.class))).thenReturn(new PublicationStatusEntity());
 
     var payload = RandomStringUtils.random(10);
-    ResponseEntity<String> restTemplateResponse = new ResponseEntity<>(payload, HttpStatusCode.valueOf(201));
+    var restTemplateResponse = new PublicationHttpResponse(payload, HttpStatusCode.valueOf(201));
 
     publicationService.updateSucceedPublicationTenantRequest(restTemplateResponse, ptrEntity, folioExecutionContext);
     verify(publicationTenantRequestRepository).save(ptreCaptor.capture());


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-48

## Approach
* fixed http status code since POST method should return 201
* Invoking `restTemplate.exchange` method with type `String.class` causes issue converting the payload. In this case StringMessageConverter used as the default and such object causes issues in all spring based modules requested by publish coordinator. As the workaround swithed ResponseEntity to type Object so JsonMessageConverter will be used instead.

verified via Karate tests https://github.com/folio-org/folio-integration-tests/pull/1022

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
