### PR TITLE
MODCON-82. Investigate why affilitation for some users were not created by automation job without timeouts

### DIFF
--- a/src/main/java/org/folio/consortia/config/FolioExecutionContextHelper.java
+++ b/src/main/java/org/folio/consortia/config/FolioExecutionContextHelper.java
@@ -24,6 +24,8 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 public class FolioExecutionContextHelper {
 
+  private static final String AUTHTOKEN_REFRESH_CACHE_HEADER = "Authtoken-Refresh-Cache";
+
   private final FolioModuleMetadata folioModuleMetadata;
   private final FolioExecutionContext folioExecutionContext;
   private final AuthService authService;
@@ -37,10 +39,11 @@ public class FolioExecutionContextHelper {
   }
 
   public FolioExecutionContext getSystemUserFolioExecutionContext(String tenantId) {
-    Map<String, Collection<String>> tenantOkapiHeaders = new HashMap<>();
-    tenantOkapiHeaders.put(XOkapiHeaders.TENANT, List.of(tenantId));
-    tenantOkapiHeaders.put(XOkapiHeaders.URL, List.of(okapiUrl));
+    Map<String, Collection<String>> headers = getOkapiHeaders(tenantId);
+    return getSystemUserFolioExecutionContext(tenantId, headers);
+  }
 
+  public FolioExecutionContext getSystemUserFolioExecutionContext(String tenantId, Map<String, Collection<String>> tenantOkapiHeaders) {
     try (var context = new FolioExecutionContextSetter(new DefaultFolioExecutionContext(folioModuleMetadata, tenantOkapiHeaders))) {
       String systemUserToken = authService.getTokenForSystemUser(tenantId, okapiUrl);
       log.debug("getSystemUserFolioExecutionContext:: {}", systemUserToken);
@@ -58,5 +61,26 @@ public class FolioExecutionContextHelper {
       }
     }
     return new DefaultFolioExecutionContext(folioModuleMetadata, tenantOkapiHeaders);
+  }
+
+  /**
+   * Gets headers with header Authtoken-Refresh-Cache = true that allows to invalidate
+   * user permissions cache that lives for 1 minute by default in mod-authtoken.
+   * Added in scope of MODCON-82 with aim to fix Forbidden exceptions thrown by mod-authtoken
+   *
+   * @param tenantId the tenant id
+   * @return map with headers
+   */
+  public Map<String, Collection<String>> getHeadersForSystemUserWithRefreshPermissions(String tenantId) {
+    Map<String, Collection<String>> headers = getOkapiHeaders(tenantId);
+    headers.put(AUTHTOKEN_REFRESH_CACHE_HEADER, List.of(Boolean.TRUE.toString()));
+    return headers;
+  }
+
+  private Map<String, Collection<String>> getOkapiHeaders(String tenantId) {
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put(XOkapiHeaders.TENANT, List.of(tenantId));
+    headers.put(XOkapiHeaders.URL, List.of(okapiUrl));
+    return headers;
   }
 }

--- a/src/main/java/org/folio/consortia/config/FolioExecutionContextHelper.java
+++ b/src/main/java/org/folio/consortia/config/FolioExecutionContextHelper.java
@@ -24,7 +24,7 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 public class FolioExecutionContextHelper {
 
-  private static final String AUTHTOKEN_REFRESH_CACHE_HEADER = "Authtoken-Refresh-Cache";
+  public static final String AUTHTOKEN_REFRESH_CACHE_HEADER = "Authtoken-Refresh-Cache";
 
   private final FolioModuleMetadata folioModuleMetadata;
   private final FolioExecutionContext folioExecutionContext;

--- a/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
@@ -30,6 +30,7 @@ import org.folio.consortia.service.PermissionUserService;
 import org.folio.consortia.service.TenantService;
 import org.folio.consortia.service.UserService;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.convert.ConversionService;
@@ -136,7 +137,8 @@ public class TenantServiceImpl implements TenantService {
     }
 
     // switch to context of the desired tenant and apply all necessary setup
-    try (var context = new FolioExecutionContextSetter(contextHelper.getSystemUserFolioExecutionContext(tenantDto.getId()))) {
+    var systemUserHeaders = contextHelper.getHeadersForSystemUserWithRefreshPermissions(tenantDto.getId());
+    try (var context = new FolioExecutionContextSetter(contextHelper.getSystemUserFolioExecutionContext(tenantDto.getId(), systemUserHeaders))) {
       configurationClient.saveConfiguration(createConsortiaConfigurationBody(centralTenantId));
       if (!tenantDto.getIsCentral()) {
         createUserTenantWithDummyUser(tenantDto.getId(), centralTenantId);

--- a/src/main/resources/log4j2-json.properties
+++ b/src/main/resources/log4j2-json.properties
@@ -28,6 +28,9 @@ appender.console.layout.moduleId.type = KeyValuePair
 appender.console.layout.moduleId.key = moduleId
 appender.console.layout.moduleId.value = $${folio:moduleid:-}
 
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size=100MB
+
 rootLogger.level = info
 rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -10,6 +10,9 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss} %t [$${folio:requestid:-}] [$${folio:tenantid:-}] [$${folio:userid:-}] [$${folio:moduleid:-}] %-5p %-20.20C{1} %m%n
 
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size=100MB
+
 logger.foliospring = debug, STDOUT
 logger.foliospring.name = org.folio.spring
 logger.foliospring.additivity = false

--- a/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
@@ -10,6 +10,7 @@ import static org.folio.consortia.utils.EntityUtils.createUser;
 import static org.folio.consortia.utils.EntityUtils.createUserTenantEntity;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -161,7 +162,7 @@ class TenantControllerTest extends BaseIT {
     when(userService.prepareShadowUser(UUID.fromString(adminUser.getId()), TENANT)).thenReturn(adminUser);
     when(userService.prepareShadowUser(UUID.fromString(systemUser.getId()), TENANT)).thenReturn(systemUser);
     when(userService.getById(any())).thenReturn(adminUser);
-    doReturn(folioExecutionContext).when(contextHelper).getSystemUserFolioExecutionContext(anyString());
+    doReturn(folioExecutionContext).when(contextHelper).getSystemUserFolioExecutionContext(anyString(), anyMap());
     doReturn(new User()).when(usersClient).getUsersByUserId(any());
     doReturn(permissionUserCollection).when(permissionsClient).get(anyString());
     doNothing().when(permissionsClient).addPermission(anyString(), any());

--- a/src/test/java/org/folio/consortia/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantServiceTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -175,7 +176,7 @@ class TenantServiceTest {
     doNothing().when(configurationClient).saveConfiguration(createConsortiaConfiguration(CENTRAL_TENANT_ID));
     doNothing().when(userTenantsClient).postUserTenant(any());
     when(conversionService.convert(localTenantEntity, Tenant.class)).thenReturn(tenant);
-    doReturn(folioExecutionContext).when(contextHelper).getSystemUserFolioExecutionContext(anyString());
+    doReturn(folioExecutionContext).when(contextHelper).getSystemUserFolioExecutionContext(anyString(), anyMap());
     when(folioExecutionContext.getTenantId()).thenReturn("diku");
 
     var tenant1 = tenantService.save(consortiumId, UUID.fromString(adminUser.getId()), tenant);
@@ -216,7 +217,7 @@ class TenantServiceTest {
     doNothing().when(configurationClient).saveConfiguration(createConsortiaConfiguration(CENTRAL_TENANT_ID));
     doNothing().when(userTenantsClient).postUserTenant(any());
     when(conversionService.convert(tenantEntity1, Tenant.class)).thenReturn(tenant);
-    doReturn(folioExecutionContext).when(contextHelper).getSystemUserFolioExecutionContext(anyString());
+    doReturn(folioExecutionContext).when(contextHelper).getSystemUserFolioExecutionContext(anyString(), anyMap());
     when(folioExecutionContext.getTenantId()).thenReturn("diku");
     Map<String, Collection<String>> okapiHeaders = new HashMap<>();
     okapiHeaders.put(XOkapiHeaders.TENANT, List.of("diku"));


### PR DESCRIPTION
## Purpose
In logs when creating consortia env without timeouts we saw 401 Forbidden for system user.
This PR tryis to resolve it by invalidating user permissions cache during tenants setup.
Mod-authtoken requires header Authtoken-Refresh-Cache to invalidate user permissions cache

Related commit with deleting timeouts: https://github.com/folio-org/pipelines-shared-library/commit/e93538ee2ad7f4f2877d41e1c8ab570b5c96758f 

Also loggign configured to use 1 big file to easily troubleshoot and fetch log file from Rancher.
![image](https://github.com/folio-org/mod-consortia/assets/25097693/c3530673-fb35-4b15-9eb5-a722c844db4b)

## Approach
Use Authtoken-Refresh-Cache = true to invalidate cache in mod-authtoken