### PR TITLE
MODCON-81. Add permission to system user to delete users

### DIFF
--- a/src/main/resources/permissions/system-user-permissions.csv
+++ b/src/main/resources/permissions/system-user-permissions.csv
@@ -3,6 +3,7 @@ users.collection.get
 users.item.get
 users.item.post
 users.item.put
+users.item.delete
 perms.users.item.put
 perms.users.item.post
 perms.users.item.delete


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-81
We need to add permission to system user to be able to delete any user during processing of USER_DELETED event