### PR TITLE
MODCON-88 add COMPLETED_WITH_ERRORS status to distinguish failures on creating primary affiliations for users

### DIFF
--- a/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
@@ -118,8 +118,8 @@ public class SyncPrimaryAffiliationServiceImpl implements SyncPrimaryAffiliation
           " and error message: {}", user.getId(), tenantId, e.getMessage(), e);
       }
     }
-    tenantService.updateTenantSetupStatus(tenantId, centralTenantId, hasFailedAffiliations ? SetupStatusEnum.FAILED
-      : SetupStatusEnum.COMPLETED);
+    tenantService.updateTenantSetupStatus(tenantId, centralTenantId, hasFailedAffiliations ?
+      SetupStatusEnum.COMPLETED_WITH_ERRORS : SetupStatusEnum.COMPLETED);
     log.info("createPrimaryUserAffiliations:: Successfully created {} of {} primary affiliations for tenant {}",
       affiliatedUsersCount, userList.size(), tenantId);
   }

--- a/src/main/resources/db/changelog/changes/create-tenant-table.xml
+++ b/src/main/resources/db/changelog/changes/create-tenant-table.xml
@@ -48,7 +48,7 @@
 
   <changeSet id="MODCON-88@add-tenant-setup-status" author="tatsiana_tarhonskaya@epam.com">
     <sql dbms="postgresql">
-      CREATE TYPE setup_status as ENUM ('IN_PROGRESS', 'COMPLETED', 'FAILED');
+      CREATE TYPE setup_status as ENUM ('IN_PROGRESS', 'COMPLETED', 'COMPLETED_WITH_ERRORS', 'FAILED');
       CREATE CAST (character varying as setup_status) WITH INOUT AS IMPLICIT;
     </sql>
     <addColumn tableName="tenant">

--- a/src/main/resources/swagger.api/schemas/tenant.yaml
+++ b/src/main/resources/swagger.api/schemas/tenant.yaml
@@ -28,7 +28,7 @@ TenantDetails:
       properties:
         setupStatus:
           type: string
-          enum: [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+          enum: [ "IN_PROGRESS", "COMPLETED", "COMPLETED_WITH_ERRORS", "FAILED" ]
 
 TenantCollection:
   type: object

--- a/src/test/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImplTest.java
+++ b/src/test/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImplTest.java
@@ -260,6 +260,6 @@ class SyncPrimaryAffiliationServiceImplTest {
 
     syncPrimaryAffiliationService.createPrimaryUserAffiliations(consortiumId, centralTenantId, spab);
     verifyNoInteractions(kafkaService);
-    verify(tenantService).updateTenantSetupStatus(tenantId, centralTenantId, SetupStatusEnum.FAILED);
+    verify(tenantService).updateTenantSetupStatus(tenantId, centralTenantId, SetupStatusEnum.COMPLETED_WITH_ERRORS);
   }
 }


### PR DESCRIPTION
[MODCON-88](https://issues.folio.org/browse/MODCON-88)

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODCONSORTIA-01 Logging Improvement
  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
 add COMPLETED_WITH_ERRORS status to distinguish failures on creating primary affiliations for users
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema."
  instead, provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  the project reconstructs the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODCONSORTIA-01
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or add-ons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
