### PR TITLE
MODCON-88. Make saving status always in new transaction

### DIFF
--- a/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
@@ -42,6 +42,7 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -180,7 +181,7 @@ public class TenantServiceImpl implements TenantService {
   }
 
   @Override
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void updateTenantSetupStatus(String tenantId, String centralTenantId, SetupStatusEnum setupStatus) {
     try (var ctx = new FolioExecutionContextSetter(prepareContextForTenant(centralTenantId,
       folioExecutionContext.getFolioModuleMetadata(), folioExecutionContext))) {


### PR DESCRIPTION
When setuping job via automation pipeline it failes for some reasons(probably because of R/W split) but original transaction roll backed and status not saved to DB.
Status is always is IN_PROGRESS
![image](https://github.com/folio-org/mod-consortia/assets/25097693/e5f63d37-5143-4966-966a-404751935787)
