### PR TITLE
MODCON-89. Improve kafka partitions

### DIFF
--- a/src/main/java/org/folio/consortia/domain/dto/UserType.java
+++ b/src/main/java/org/folio/consortia/domain/dto/UserType.java
@@ -1,0 +1,17 @@
+package org.folio.consortia.domain.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum UserType {
+  PATRON("patron"),
+  STAFF("staff"),
+  SHADOW("shadow"),
+  SYSTEM("system");
+
+  UserType(String name) {
+    this.name = name;
+  }
+
+  private final String name;
+}

--- a/src/main/java/org/folio/consortia/security/SecurityManagerService.java
+++ b/src/main/java/org/folio/consortia/security/SecurityManagerService.java
@@ -8,6 +8,7 @@ import org.folio.consortia.domain.dto.PermissionUser;
 import org.folio.consortia.domain.dto.Personal;
 import org.folio.consortia.domain.dto.SystemUserParameters;
 import org.folio.consortia.domain.dto.User;
+import org.folio.consortia.domain.dto.UserType;
 import org.folio.consortia.service.PermissionUserService;
 import org.folio.consortia.service.UserService;
 import org.springframework.beans.factory.annotation.Value;
@@ -81,6 +82,7 @@ public class SecurityManagerService {
     result.setId(UUID.randomUUID().toString());
     result.setActive(true);
     result.setUsername(username);
+    result.setType(UserType.SYSTEM.getName());
 
     populateMissingUserProperties(result);
 

--- a/src/main/java/org/folio/consortia/service/impl/SharingInstanceServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SharingInstanceServiceImpl.java
@@ -101,7 +101,7 @@ public class SharingInstanceServiceImpl implements SharingInstanceService {
       sharingInstance.setStatus(Status.COMPLETE);
     } else {
       String data = objectMapper.writeValueAsString(sharingInstance);
-      kafkaService.send(KafkaService.Topic.CONSORTIUM_INSTANCE_SHARING_INIT, String.valueOf(consortiumId), data);
+      kafkaService.send(KafkaService.Topic.CONSORTIUM_INSTANCE_SHARING_INIT, String.valueOf(sharingInstance.getId()), data);
 
       sharingInstance.setStatus(Status.IN_PROGRESS);
     }

--- a/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
@@ -133,7 +133,7 @@ public class SyncPrimaryAffiliationServiceImpl implements SyncPrimaryAffiliation
   private void sendCreatePrimaryAffiliationEvent(TenantEntity consortiaTenant, SyncUser user, String centralTenantId) {
     PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(user, consortiaTenant.getId(), centralTenantId);
     String data = objectMapper.writeValueAsString(affiliationEvent);
-    kafkaService.send(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED, consortiaTenant.getConsortiumId().toString(), data);
+    kafkaService.send(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED, user.getId(), data);
   }
 
   private UserTenant createUserTenant(String tenantId, SyncUser user) {

--- a/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
@@ -46,19 +46,19 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
     }
 
     try {
-      var consortiaTenant = tenantService.getByTenantId(userEvent.getTenantId());
+      var tenant = tenantService.getByTenantId(userEvent.getTenantId());
 
       boolean isPrimaryAffiliationExists = userTenantService
-        .checkUserIfHasPrimaryAffiliationByUserId(consortiaTenant.getConsortiumId(), userEvent.getUserDto().getId());
+        .checkUserIfHasPrimaryAffiliationByUserId(tenant.getConsortiumId(), userEvent.getUserDto().getId());
       if (isPrimaryAffiliationExists) {
         log.warn("Primary affiliation already exists for tenant/user: {}/{}", userEvent.getTenantId(), userEvent.getUserDto().getUsername());
         return;
       }
 
-      userTenantService.createPrimaryUserTenantAffiliation(consortiaTenant.getConsortiumId(), consortiaTenant,
+      userTenantService.createPrimaryUserTenantAffiliation(tenant.getConsortiumId(), tenant,
         userEvent.getUserDto().getId(), userEvent.getUserDto().getUsername());
-      if (ObjectUtils.notEqual(centralTenantId, consortiaTenant.getId())) {
-        userTenantService.save(consortiaTenant.getConsortiumId(), createUserTenant(centralTenantId, userEvent), false);
+      if (ObjectUtils.notEqual(centralTenantId, tenant.getId())) {
+        userTenantService.save(tenant.getConsortiumId(), createUserTenant(centralTenantId, userEvent), false);
       }
 
       PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId);

--- a/src/main/java/org/folio/consortia/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import org.folio.consortia.client.UsersClient;
 import org.folio.consortia.domain.dto.Personal;
 import org.folio.consortia.domain.dto.User;
+import org.folio.consortia.domain.dto.UserType;
 import org.folio.consortia.exception.ConsortiumClientException;
 import org.folio.consortia.exception.ResourceNotFoundException;
 import org.folio.consortia.service.UserService;
@@ -29,7 +30,6 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
   private static final String USER_ID = "userId";
-  private static final String SHADOW_USER_TYPE = "shadow";
 
   private final UsersClient usersClient;
   private final FolioExecutionContext folioExecutionContext;
@@ -91,7 +91,7 @@ public class UserServiceImpl implements UserService {
       if (Objects.nonNull(userOptional.getId())) {
         user.setId(userId.toString());
         user.setUsername(String.format("%s_%s", userOptional.getUsername(), HelperUtils.randomString(RANDOM_STRING_COUNT)));
-        user.setType(SHADOW_USER_TYPE);
+        user.setType(UserType.SHADOW.getName());
         user.setActive(true);
         if (Objects.nonNull(userOptional.getPersonal())) {
           // these firstname, lastname fields needed to correctly build UI metadata objects

--- a/src/test/java/org/folio/consortia/security/SecurityManagerServiceTest.java
+++ b/src/test/java/org/folio/consortia/security/SecurityManagerServiceTest.java
@@ -33,6 +33,7 @@ class SecurityManagerServiceTest extends BaseIT {
           + "            \"id\": \"a85c45b7-d427-4122-8532-5570219c5e59\",\n"
           + "            \"active\": true,\n"
           + "            \"departments\": [],\n"
+          + "            \"type\":  \"system\",\n"
           + "            \"proxyFor\": [],\n"
           + "            \"personal\": {\n"
           + "                \"addresses\": []\n"

--- a/src/test/java/org/folio/consortia/service/UserServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 
 import org.folio.consortia.client.UsersClient;
 import org.folio.consortia.domain.dto.User;
+import org.folio.consortia.domain.dto.UserType;
 import org.folio.consortia.service.impl.UserServiceImpl;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
@@ -79,7 +80,7 @@ class UserServiceTest {
     when(folioExecutionContext.getOkapiHeaders()).thenReturn(okapiHeaders);
     Mockito.when(usersClient.getUsersByUserId(any())).thenReturn(createUserEntity(true));
     User user = userService.prepareShadowUser(UUID.randomUUID(), "diku");
-    Assertions.assertEquals("shadow", user.getType());
+    Assertions.assertEquals(UserType.SHADOW.getName(), user.getType());
     Assertions.assertEquals("diku", user.getCustomFields().get("originaltenantid"));
     Assertions.assertEquals(true, user.getActive());
     Assertions.assertEquals("testFirst", user.getPersonal().getFirstName());


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-89

## Approach

- Simplify kafka consumers logic
- Use userId as partition key for user events, it can allow to distribute kafka messages accross partitions and in the same way garantee that order of event for particular user is kept
- Use sharing instance action id for Sharing Instance events, Folijet will use this key for message deduplication to not process duplicates