### PR TITLE
MODCON-91. Add consortiumId to user tenant table

### DIFF
--- a/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
@@ -114,7 +114,7 @@ public class SyncPrimaryAffiliationServiceImpl implements SyncPrimaryAffiliation
           if (ObjectUtils.notEqual(centralTenantId, tenantEntity.getId())) {
             userTenantService.save(consortiumId, createUserTenant(centralTenantId, user), true);
           }
-          sendCreatePrimaryAffiliationEvent(tenantEntity, user, centralTenantId);
+          sendCreatePrimaryAffiliationEvent(tenantEntity, user, centralTenantId, consortiumId);
         }
         affiliatedUsersCount++;
       } catch (Exception e) {
@@ -130,8 +130,8 @@ public class SyncPrimaryAffiliationServiceImpl implements SyncPrimaryAffiliation
   }
 
   @SneakyThrows
-  private void sendCreatePrimaryAffiliationEvent(TenantEntity consortiaTenant, SyncUser user, String centralTenantId) {
-    PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(user, consortiaTenant.getId(), centralTenantId);
+  private void sendCreatePrimaryAffiliationEvent(TenantEntity consortiaTenant, SyncUser user, String centralTenantId, UUID consortiumId) {
+    PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(user, consortiaTenant.getId(), centralTenantId, consortiumId);
     String data = objectMapper.writeValueAsString(affiliationEvent);
     kafkaService.send(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED, user.getId(), data);
   }
@@ -144,7 +144,10 @@ public class SyncPrimaryAffiliationServiceImpl implements SyncPrimaryAffiliation
     return userTenant;
   }
 
-  private PrimaryAffiliationEvent createPrimaryAffiliationEvent(SyncUser user, String tenantId, String centralTenantId) {
+  private PrimaryAffiliationEvent createPrimaryAffiliationEvent(SyncUser user,
+                                                                String tenantId,
+                                                                String centralTenantId,
+                                                                UUID consortiumId) {
     PrimaryAffiliationEvent event = new PrimaryAffiliationEvent();
     event.setId(UUID.randomUUID());
     event.setUserId(UUID.fromString(user.getId()));
@@ -156,6 +159,7 @@ public class SyncPrimaryAffiliationServiceImpl implements SyncPrimaryAffiliation
     event.setBarcode(user.getBarcode());
     event.setExternalSystemId(user.getExternalSystemId());
     event.setCentralTenantId(centralTenantId);
+    event.setConsortiumId(consortiumId);
     return event;
   }
 }

--- a/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
@@ -159,7 +159,7 @@ public class TenantServiceImpl implements TenantService {
     try (var context = new FolioExecutionContextSetter(contextHelper.getSystemUserFolioExecutionContext(tenantDto.getId(), systemUserHeaders))) {
       configurationClient.saveConfiguration(createConsortiaConfigurationBody(centralTenantId));
       if (!tenantDto.getIsCentral()) {
-        createUserTenantWithDummyUser(tenantDto.getId(), centralTenantId);
+        createUserTenantWithDummyUser(tenantDto.getId(), centralTenantId, consortiumId);
         createShadowUserWithPermissions(shadowAdminUser, SHADOW_ADMIN_PERMISSION_FILE_PATH); //NOSONAR
         log.info("save:: shadow admin user '{}' with permissions was created in tenant '{}'", shadowAdminUser.getId(), tenantDto.getId());
         createShadowUserWithPermissions(shadowSystemUser, SHADOW_SYSTEM_USER_PERMISSION_FILE_PATH);
@@ -227,14 +227,16 @@ public class TenantServiceImpl implements TenantService {
 
     @param tenantId tenant id
     @param centralTenantId central tenant id
+    @param consortiumId consortium id
   */
-  private void createUserTenantWithDummyUser(String tenantId, String centralTenantId) {
+  private void createUserTenantWithDummyUser(String tenantId, String centralTenantId, UUID consortiumId) {
     UserTenant userTenant = new UserTenant();
     userTenant.setId(UUID.randomUUID());
     userTenant.setTenantId(tenantId);
     userTenant.setUserId(UUID.randomUUID());
     userTenant.setUsername(DUMMY_USERNAME);
     userTenant.setCentralTenantId(centralTenantId);
+    userTenant.setConsortiumId(consortiumId);
 
     log.info("Creating userTenant with dummy user with id {}.", userTenant.getId());
     userTenantsClient.postUserTenant(userTenant);

--- a/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
@@ -61,7 +61,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
         userTenantService.save(tenant.getConsortiumId(), createUserTenant(centralTenantId, userEvent), false);
       }
 
-      PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId);
+      PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId, tenant.getConsortiumId());
       String data = objectMapper.writeValueAsString(affiliationEvent);
 
       kafkaService.send(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED, userEvent.getUserDto().getId(), data);
@@ -97,7 +97,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
       if (Boolean.TRUE.equals(userEvent.getIsPersonalDataChanged())) {
         userTenantService.updateShadowUsersFirstAndLastNames(getUserId(userEvent));
       }
-      PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId);
+      PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId, null);
       String data = objectMapper.writeValueAsString(affiliationEvent);
 
       kafkaService.send(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_UPDATED, userEvent.getUserDto().getId(), data);
@@ -126,7 +126,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
 
       userTenantService.deleteShadowUsers(getUserId(userEvent));
 
-      PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId);
+      PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId, null);
       String data = objectMapper.writeValueAsString(affiliationEvent);
 
       kafkaService.send(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_DELETED, userEvent.getUserDto().getId(), data);
@@ -164,7 +164,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
     return userTenant;
   }
 
-  private PrimaryAffiliationEvent createPrimaryAffiliationEvent(UserEvent userEvent, String centralTenantId) {
+  private PrimaryAffiliationEvent createPrimaryAffiliationEvent(UserEvent userEvent, String centralTenantId, UUID consortiumId) {
     PrimaryAffiliationEvent event = new PrimaryAffiliationEvent();
     event.setId(userEvent.getId());
     event.setUserId(UUID.fromString(userEvent.getUserDto().getId()));
@@ -185,6 +185,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
     }
     event.setTenantId(userEvent.getTenantId());
     event.setCentralTenantId(centralTenantId);
+    event.setConsortiumId(consortiumId);
     return event;
   }
 }

--- a/src/main/resources/swagger.api/schemas/primaryAffiliationEvent.yaml
+++ b/src/main/resources/swagger.api/schemas/primaryAffiliationEvent.yaml
@@ -17,6 +17,9 @@ properties:
   centralTenantId:
     description: "The name of the user's central tenant"
     type: string
+  consortiumId:
+    description: "The consortium uuid that user belongs to"
+    $ref: "uuid.yaml"
   email:
     description: "The user's email"
     type: string

--- a/src/main/resources/swagger.api/schemas/userTenant.yaml
+++ b/src/main/resources/swagger.api/schemas/userTenant.yaml
@@ -18,6 +18,9 @@ UserTenant:
       type: boolean
     centralTenantId:
       type: string
+    consortiumId:
+      type: string
+      format: uuid
     email:
       type: string
     mobilePhoneNumber:


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-91

## Approach
Populate consortiumId when created dummy user teant, when affiliate existing users and when processing user created event.
For user updated and user deleted this field can be skipped