### PR TITLE
MODCON-93. Improve transaction behavior when migrating existing users to consortia

### DIFF
--- a/src/main/java/org/folio/consortia/config/kafka/KafkaService.java
+++ b/src/main/java/org/folio/consortia/config/kafka/KafkaService.java
@@ -137,16 +137,15 @@ public class KafkaService {
   }
 
   public void send(Topic topic, String key, String data) {
-    log.info("Sending {}.", data);
     String tenant = folioExecutionContext.getTenantId();
     if (StringUtils.isBlank(tenant)) {
       throw new IllegalStateException("Can't send to Kafka because tenant is blank");
     }
     String tenantTopicName = getTenantTopicName(topic.getTopicName(), tenant);
-
+    log.debug("Sending event with key: {} to topic: {} for tenant: {}", key, tenantTopicName, tenant);
     ProducerRecord<String, Object> producerRecord = createProducerRecord(tenantTopicName, key, data);
     kafkaTemplate.send(producerRecord);
-    log.info("Kafka event sent to topic: {} for tenant: {} with data: {}.", tenantTopicName, tenant, data);
+    log.info("Kafka event sent with key: {} to topic: {} for tenant: {}", key, tenantTopicName, tenant);
   }
 
   private ProducerRecord<String, Object> createProducerRecord(String tenantTopicName, String key, String data) {

--- a/src/main/java/org/folio/consortia/service/PrimaryAffiliationService.java
+++ b/src/main/java/org/folio/consortia/service/PrimaryAffiliationService.java
@@ -1,0 +1,41 @@
+package org.folio.consortia.service;
+
+import org.folio.consortia.domain.dto.PrimaryAffiliationEvent;
+import org.folio.consortia.domain.entity.TenantEntity;
+
+import java.util.UUID;
+
+public interface PrimaryAffiliationService {
+  /**
+   * Creates primary affiliation and sends event to kafka using system user context.
+   * If tenant is member - additional affiliation will be created in central tenant as well.
+   * This method uses Sprint REQUIRES_NEW propagation type to create each affiliation in new transaction.
+   * It can be useful in places that already have open transaction and creating affiliations for multiple users -
+   * in this case if some particular affiliation was not created - the entire outer transaction will not be roll backed.
+   *
+   * @param consortiumId the consortium id
+   * @param centralTenantId the central tenant id
+   * @param tenantEntity the tenant entity
+   * @param event the primary affiliation event to send to kafka
+   */
+  void createPrimaryAffiliationInNewTransaction(UUID consortiumId,
+                                                String centralTenantId,
+                                                TenantEntity tenantEntity,
+                                                PrimaryAffiliationEvent event);
+
+  /**
+   * Creates primary affiliation and sends event to kafka using system user context.
+   * If tenant is member - additional affiliation will be created in central tenant as well.
+   * This method also transactional and joins already created outer transaction(if exists) or creates new one.
+   * It can be useful in places that creates single affiliation like processing user domain events.
+   *
+   * @param consortiumId the consortium id
+   * @param centralTenantId the central tenant id
+   * @param tenantEntity the tenant entity
+   * @param event the primary affiliation event to send to kafka
+   */
+  void createPrimaryAffiliation(UUID consortiumId,
+                                String centralTenantId,
+                                TenantEntity tenantEntity,
+                                PrimaryAffiliationEvent event);
+}

--- a/src/main/java/org/folio/consortia/service/impl/PrimaryAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PrimaryAffiliationServiceImpl.java
@@ -1,0 +1,68 @@
+package org.folio.consortia.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.ObjectUtils;
+import org.folio.consortia.config.kafka.KafkaService;
+import org.folio.consortia.domain.dto.PrimaryAffiliationEvent;
+import org.folio.consortia.domain.dto.UserTenant;
+import org.folio.consortia.domain.entity.TenantEntity;
+import org.folio.consortia.service.PrimaryAffiliationService;
+import org.folio.consortia.service.UserTenantService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class PrimaryAffiliationServiceImpl implements PrimaryAffiliationService {
+
+  private final UserTenantService userTenantService;
+  private final KafkaService kafkaService;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void createPrimaryAffiliationInNewTransaction(UUID consortiumId,
+                                                       String centralTenantId,
+                                                       TenantEntity tenantEntity,
+                                                       PrimaryAffiliationEvent event) {
+    createAndSendEvent(consortiumId, centralTenantId, tenantEntity, event);
+  }
+
+  @Override
+  @Transactional
+  public void createPrimaryAffiliation(UUID consortiumId,
+                                       String centralTenantId,
+                                       TenantEntity tenantEntity,
+                                       PrimaryAffiliationEvent event) {
+    createAndSendEvent(consortiumId, centralTenantId, tenantEntity, event);
+  }
+
+  @SneakyThrows
+  private void createAndSendEvent(UUID consortiumId,
+                                  String centralTenantId,
+                                  TenantEntity tenantEntity,
+                                  PrimaryAffiliationEvent event) {
+    userTenantService.createPrimaryUserTenantAffiliation(consortiumId, tenantEntity, event.getUserId().toString(), event.getUsername());
+    if (ObjectUtils.notEqual(centralTenantId, tenantEntity.getId())) {
+      userTenantService.save(consortiumId, createUserTenant(centralTenantId, event.getUserId(), event.getUsername()), true);
+    }
+    String data = objectMapper.writeValueAsString(event);
+    kafkaService.send(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED, event.getUserId().toString(), data);
+    log.info("Primary affiliation has been created and event sent for the user: {}", event.getUserId());
+  }
+
+  private UserTenant createUserTenant(String tenantId, UUID userId, String username) {
+    UserTenant userTenant = new UserTenant();
+    userTenant.setTenantId(tenantId);
+    userTenant.setUserId(userId);
+    userTenant.setUsername(username);
+    return userTenant;
+  }
+}

--- a/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
@@ -149,14 +149,6 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
     return UUID.fromString(userEvent.getUserDto().getId());
   }
 
-  private UserTenant createUserTenant(String tenantId, UserEvent userEvent) {
-    UserTenant userTenant = new UserTenant();
-    userTenant.setTenantId(tenantId);
-    userTenant.setUserId(UUID.fromString(userEvent.getUserDto().getId()));
-    userTenant.setUsername(userEvent.getUserDto().getUsername());
-    return userTenant;
-  }
-
   private PrimaryAffiliationEvent createPrimaryAffiliationEvent(UserEvent userEvent, String centralTenantId, UUID consortiumId) {
     PrimaryAffiliationEvent event = new PrimaryAffiliationEvent();
     event.setId(userEvent.getId());

--- a/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
@@ -11,6 +11,7 @@ import org.folio.consortia.domain.dto.User;
 import org.folio.consortia.domain.dto.UserEvent;
 import org.folio.consortia.domain.dto.UserTenant;
 import org.folio.consortia.domain.entity.UserTenantEntity;
+import org.folio.consortia.service.PrimaryAffiliationService;
 import org.folio.consortia.service.TenantService;
 import org.folio.consortia.service.UserAffiliationService;
 import org.folio.consortia.service.UserTenantService;
@@ -33,6 +34,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
   private final TenantService tenantService;
   private final KafkaService kafkaService;
   private final FolioExecutionContext folioExecutionContext;
+  private final PrimaryAffiliationService primaryAffiliationService;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Override
@@ -55,17 +57,8 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
         return;
       }
 
-      userTenantService.createPrimaryUserTenantAffiliation(tenant.getConsortiumId(), tenant,
-        userEvent.getUserDto().getId(), userEvent.getUserDto().getUsername());
-      if (ObjectUtils.notEqual(centralTenantId, tenant.getId())) {
-        userTenantService.save(tenant.getConsortiumId(), createUserTenant(centralTenantId, userEvent), false);
-      }
-
       PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId, tenant.getConsortiumId());
-      String data = objectMapper.writeValueAsString(affiliationEvent);
-
-      kafkaService.send(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED, userEvent.getUserDto().getId(), data);
-      log.info("Primary affiliation has been set for the user: {}", userEvent.getUserDto().getId());
+      primaryAffiliationService.createPrimaryAffiliation(tenant.getConsortiumId(), centralTenantId, tenant, affiliationEvent);
     } catch (Exception e) {
       log.error("Exception occurred while creating primary affiliation for userId: {}, tenant: {} and error message: {}",
         userEvent.getUserDto().getId(), userEvent.getTenantId(), e.getMessage(), e);

--- a/src/test/java/org/folio/consortia/service/PrimaryAffiliationServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/PrimaryAffiliationServiceTest.java
@@ -1,0 +1,105 @@
+package org.folio.consortia.service;
+
+import org.folio.consortia.config.kafka.KafkaService;
+import org.folio.consortia.domain.dto.PrimaryAffiliationEvent;
+import org.folio.consortia.domain.dto.UserTenant;
+import org.folio.consortia.domain.entity.TenantEntity;
+import org.folio.consortia.service.impl.PrimaryAffiliationServiceImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class PrimaryAffiliationServiceTest {
+  private static final UUID CONSORTIUM_ID = UUID.randomUUID();
+  private static final String CENTRAL_TENANT_ID = "consortium";
+  private static final String MEMBER_TENANT_ID = "university";
+  private static final UUID USER_ID = UUID.randomUUID();
+  private static final String USERNAME = "username";
+  @Mock
+  private UserTenantService userTenantService;
+  @Mock
+  private KafkaService kafkaService;
+  @InjectMocks
+  private PrimaryAffiliationServiceImpl primaryAffiliationService;
+  AutoCloseable mockitoMocks;
+
+  @BeforeEach
+  public void beforeEach() {
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void afterEach() throws Exception {
+    mockitoMocks.close();
+  }
+
+  @Test
+  public void testRequiresNewTransactionForCentralTenant() {
+    TenantEntity tenantEntity = new TenantEntity();
+    tenantEntity.setId(CENTRAL_TENANT_ID);
+    PrimaryAffiliationEvent event = getPrimaryAffiliationEvent();
+
+    primaryAffiliationService.createPrimaryAffiliationInNewTransaction(CONSORTIUM_ID, CENTRAL_TENANT_ID, tenantEntity, event);
+
+    verify(userTenantService).createPrimaryUserTenantAffiliation(CONSORTIUM_ID, tenantEntity, USER_ID.toString(), USERNAME);
+    verify(userTenantService, never()).save(eq(CONSORTIUM_ID), any(UserTenant.class), eq(true));
+    verify(kafkaService).send(eq(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED), eq(event.getUserId().toString()), anyString());
+  }
+
+  @Test
+  public void testRequiresNewTransactionForMemberTenant() {
+    TenantEntity tenantEntity = new TenantEntity();
+    tenantEntity.setId(MEMBER_TENANT_ID);
+    PrimaryAffiliationEvent event = getPrimaryAffiliationEvent();
+
+    primaryAffiliationService.createPrimaryAffiliationInNewTransaction(CONSORTIUM_ID, CENTRAL_TENANT_ID, tenantEntity, event);
+
+    verify(userTenantService).createPrimaryUserTenantAffiliation(CONSORTIUM_ID, tenantEntity, USER_ID.toString(), USERNAME);
+    verify(userTenantService).save(eq(CONSORTIUM_ID), any(UserTenant.class), eq(true));
+    verify(kafkaService).send(eq(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED), eq(event.getUserId().toString()), anyString());
+  }
+
+  @Test
+  public void testSupportTransactionForCentralTenant() {
+    TenantEntity tenantEntity = new TenantEntity();
+    tenantEntity.setId(CENTRAL_TENANT_ID);
+    PrimaryAffiliationEvent event = getPrimaryAffiliationEvent();
+
+    primaryAffiliationService.createPrimaryAffiliation(CONSORTIUM_ID, CENTRAL_TENANT_ID, tenantEntity, event);
+
+    verify(userTenantService).createPrimaryUserTenantAffiliation(CONSORTIUM_ID, tenantEntity, USER_ID.toString(), USERNAME);
+    verify(userTenantService, never()).save(eq(CONSORTIUM_ID), any(UserTenant.class), eq(true));
+    verify(kafkaService).send(eq(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED), eq(event.getUserId().toString()), anyString());
+  }
+
+  @Test
+  public void testSupportTransactionForMemberTenant() {
+    TenantEntity tenantEntity = new TenantEntity();
+    tenantEntity.setId(MEMBER_TENANT_ID);
+    PrimaryAffiliationEvent event = getPrimaryAffiliationEvent();
+
+    primaryAffiliationService.createPrimaryAffiliation(CONSORTIUM_ID, CENTRAL_TENANT_ID, tenantEntity, event);
+
+    verify(userTenantService).createPrimaryUserTenantAffiliation(CONSORTIUM_ID, tenantEntity, USER_ID.toString(), USERNAME);
+    verify(userTenantService).save(eq(CONSORTIUM_ID), any(UserTenant.class), eq(true));
+    verify(kafkaService).send(eq(KafkaService.Topic.CONSORTIUM_PRIMARY_AFFILIATION_CREATED), eq(event.getUserId().toString()), anyString());
+  }
+
+  private PrimaryAffiliationEvent getPrimaryAffiliationEvent() {
+    PrimaryAffiliationEvent event = new PrimaryAffiliationEvent();
+    event.setUserId(USER_ID);
+    event.setUsername(USERNAME);
+    return event;
+  }
+}

--- a/src/test/java/org/folio/consortia/service/PrimaryAffiliationServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/PrimaryAffiliationServiceTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class PrimaryAffiliationServiceTest {
+class PrimaryAffiliationServiceTest {
   private static final UUID CONSORTIUM_ID = UUID.randomUUID();
   private static final String CENTRAL_TENANT_ID = "consortium";
   private static final String MEMBER_TENANT_ID = "university";
@@ -45,7 +45,7 @@ public class PrimaryAffiliationServiceTest {
   }
 
   @Test
-  public void testRequiresNewTransactionForCentralTenant() {
+  void testRequiresNewTransactionForCentralTenant() {
     TenantEntity tenantEntity = new TenantEntity();
     tenantEntity.setId(CENTRAL_TENANT_ID);
     PrimaryAffiliationEvent event = getPrimaryAffiliationEvent();
@@ -58,7 +58,7 @@ public class PrimaryAffiliationServiceTest {
   }
 
   @Test
-  public void testRequiresNewTransactionForMemberTenant() {
+  void testRequiresNewTransactionForMemberTenant() {
     TenantEntity tenantEntity = new TenantEntity();
     tenantEntity.setId(MEMBER_TENANT_ID);
     PrimaryAffiliationEvent event = getPrimaryAffiliationEvent();
@@ -71,7 +71,7 @@ public class PrimaryAffiliationServiceTest {
   }
 
   @Test
-  public void testSupportTransactionForCentralTenant() {
+  void testSupportTransactionForCentralTenant() {
     TenantEntity tenantEntity = new TenantEntity();
     tenantEntity.setId(CENTRAL_TENANT_ID);
     PrimaryAffiliationEvent event = getPrimaryAffiliationEvent();
@@ -84,7 +84,7 @@ public class PrimaryAffiliationServiceTest {
   }
 
   @Test
-  public void testSupportTransactionForMemberTenant() {
+  void testSupportTransactionForMemberTenant() {
     TenantEntity tenantEntity = new TenantEntity();
     tenantEntity.setId(MEMBER_TENANT_ID);
     PrimaryAffiliationEvent event = getPrimaryAffiliationEvent();

--- a/src/test/java/org/folio/consortia/service/UserAffiliationServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserAffiliationServiceTest.java
@@ -55,6 +55,8 @@ class UserAffiliationServiceTest {
   @Mock
   KafkaService kafkaService;
   @Mock
+  PrimaryAffiliationService primaryAffiliationService;
+  @Mock
   FolioExecutionContext folioExecutionContext;
   AutoCloseable mockitoMocks;
 
@@ -84,7 +86,7 @@ class UserAffiliationServiceTest {
       userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
     }
 
-    verify(kafkaService, times(1)).send(any(), anyString(), any());
+    verify(primaryAffiliationService, times(1)).createPrimaryAffiliation(any(), anyString(), any(), any());
 
   }
 
@@ -103,7 +105,7 @@ class UserAffiliationServiceTest {
       userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
     }
 
-    verify(kafkaService, times(1)).send(any(), anyString(), any());
+    verify(primaryAffiliationService, times(1)).createPrimaryAffiliation(any(), anyString(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-93

## Overview:

We faced an issue on Rancher when some modules created sample users without last name populated and these couple broken users rolled back the main outer transaction to affiliate all existing users, so as a result primary affiliation was not created for all users even correct.

This behaviour started to apprear after we made some changes in transactional model to levarage PostgreSql transactional advisory locks.
And this advisory lock was added to eliminate the possibility to add users from multiple  tenants simultaneously and it requires transaction, so outer transaction when we started migration all existing users were used.

## Implementation approach:

Use transaction propagation REQUIRES_NEW to create a new transaction to process each individual user, in this case if some corrupted user will not be created - only a particular transaction for that user will be reverted, but not outer transaction.

## Bonus

- Code is refactored to extract separate service that allows to avoid duplication of creating primary affiliations in 2 places
- After adding logic to pocess user domain events by system user - creating primary affiliation for that event processing also should use system user context