### PR TITLE
MODCON-93. Add userId to kafka events

### DIFF
--- a/src/main/java/org/folio/consortia/config/kafka/KafkaService.java
+++ b/src/main/java/org/folio/consortia/config/kafka/KafkaService.java
@@ -7,6 +7,7 @@ import static org.folio.consortia.messaging.listener.ConsortiaSharingInstanceEve
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
@@ -41,7 +42,6 @@ public class KafkaService {
   private final FolioExecutionContext folioExecutionContext;
   private final KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
   private final FolioKafkaProperties folioKafkaProperties;
-  private final Environment springEnvironment;
   private final String kafkaEnvId;
   private final KafkaTemplate<String, Object> kafkaTemplate;
 
@@ -153,6 +153,9 @@ public class KafkaService {
     producerRecord.headers().add(XOkapiHeaders.TENANT, folioExecutionContext.getTenantId().getBytes(StandardCharsets.UTF_8));
     producerRecord.headers().add(XOkapiHeaders.TOKEN, folioExecutionContext.getToken().getBytes(StandardCharsets.UTF_8));
     producerRecord.headers().add(XOkapiHeaders.URL, folioExecutionContext.getOkapiUrl().getBytes(StandardCharsets.UTF_8));
+    if (Objects.nonNull(folioExecutionContext.getUserId())) {
+      producerRecord.headers().add(XOkapiHeaders.USER_ID, folioExecutionContext.getUserId().toString().getBytes(StandardCharsets.UTF_8));
+    }
     return producerRecord;
   }
 }


### PR DESCRIPTION
## Purpose
User id is necessary for importing marc files, that invokes Sharing instances endpoints.
To do such import need to create job execution that accepts this payload:
`{
  "sourceType": "ONLINE",
  "userId": "a0086f7e-61b6-5c2d-9e1b-b268063a44b3"
}`
Also in folio-spring-base this userId param can be as null so added null check in this PR:
![image](https://github.com/folio-org/mod-consortia/assets/25097693/807e420a-79b7-4bc5-a0aa-d2b6dd7b0eb2)
