### PR TITLE
[MODCON-95] - Increase character limit of consortia member Code

### DIFF
--- a/src/main/resources/swagger.api/schemas/tenant.yaml
+++ b/src/main/resources/swagger.api/schemas/tenant.yaml
@@ -5,8 +5,8 @@ Tenant:
       type: string
     code:
       type: string
-      minLength: 3
-      maxLength: 3
+      minLength: 2
+      maxLength: 5
       pattern: "^[a-zA-Z0-9]*$"
     name:
       type: string


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-95
## Approach
Change the limit character of the Consortia member code in the Tenant Schema that does validation

## Result 
![image](https://github.com/folio-org/mod-consortia/assets/113523904/859a43c7-ae41-4d15-99f5-4298372130cd)
![image](https://github.com/folio-org/mod-consortia/assets/113523904/8c0ff6ed-cbf7-4c72-87d9-87010856c8df)
![image](https://github.com/folio-org/mod-consortia/assets/113523904/5837f0d4-8d2f-4e62-ab9d-3e2bb9714ec8)
