### PR TITLE
UICONSET-69. Allow user to share Inventory - Instances - Classification identifier types

### DIFF
--- a/src/main/resources/permissions/system-user-permissions.csv
+++ b/src/main/resources/permissions/system-user-permissions.csv
@@ -28,6 +28,9 @@ inventory-storage.loan-types.item.delete
 inventory-storage.item-note-types.item.post
 inventory-storage.item-note-types.item.put
 inventory-storage.item-note-types.item.delete
+inventory-storage.classification-types.item.post
+inventory-storage.classification-types.item.put
+inventory-storage.classification-types.item.delete
 inventory-storage.electronic-access-relationships.item.post
 inventory-storage.electronic-access-relationships.item.put
 inventory-storage.electronic-access-relationships.item.delete


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UICONSET-69

Fix this issue:
{
    "id": "3e520a4c-907d-458d-90b8-f6905ee31443",
    "status": "ERROR",
    "dateTime": "2023-09-25T12:45:08.564458",
    "request": "{\"source\":\"consortium\",\"name\":\"SharedN\",\"id\":\"00571e6e-95d6-44b8-a837-69bf15033ebc\"}",
    "errors": [
        {
            "tenantId": "college",
            "errorMessage": "403 403 Forbidden: \"Access for user 'consortia-system-user' (e9e9ccda-e94a-4daa-be40-4a58453e3be3) requires permission: inventory-storage.classification-types.item.post\"",
            "errorCode": 400
        },
        {
            "tenantId": "consortium",
            "errorMessage": "403 403 Forbidden: \"Access for user 'consortia-system-user' (e9e9ccda-e94a-4daa-be40-4a58453e3be3) requires permission: inventory-storage.classification-types.item.post\"",
            "errorCode": 400
        },
        {
            "tenantId": "university",
            "errorMessage": "403 403 Forbidden: \"Access for user 'consortia-system-user' (e9e9ccda-e94a-4daa-be40-4a58453e3be3) requires permission: inventory-storage.classification-types.item.post\"",
            "errorCode": 400
        }
    ]
}