### PR TITLE
MODCON-101. Create primary affiliation after changing user type from patron to staff

### DIFF
--- a/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
@@ -86,7 +86,8 @@ public class SyncPrimaryAffiliationServiceImpl implements SyncPrimaryAffiliation
         .mobilePhoneNumber(personal.getMobilePhone());
     }
     if (StringUtils.isBlank(user.getType())) {
-      log.warn("Required field 'type' was not populated for existing user with id: {} in tenant: {}", user.getId(), tenantId);
+      log.warn("Required field 'type' was not populated for existing user with id: {}, username: {} in tenant: {}",
+        user.getId(), user.getUsername(), tenantId);
     }
     return syncUser;
   }

--- a/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.consortia.client.SyncPrimaryAffiliationClient;
 import org.folio.consortia.domain.dto.Personal;
 import org.folio.consortia.domain.dto.PrimaryAffiliationEvent;
@@ -67,11 +68,11 @@ public class SyncPrimaryAffiliationServiceImpl implements SyncPrimaryAffiliation
     return new SyncPrimaryAffiliationBody()
       .tenantId(tenantId)
       .users(users.stream()
-        .map(this::getSyncUser)
+        .map(user -> getSyncUser(user, tenantId))
         .toList());
   }
 
-  private SyncUser getSyncUser(User user) {
+  private SyncUser getSyncUser(User user, String tenantId) {
     SyncUser syncUser = new SyncUser()
       .id(user.getId())
       .username(user.getUsername())
@@ -83,6 +84,9 @@ public class SyncPrimaryAffiliationServiceImpl implements SyncPrimaryAffiliation
         .email(personal.getEmail())
         .phoneNumber(personal.getPhone())
         .mobilePhoneNumber(personal.getMobilePhone());
+    }
+    if (StringUtils.isBlank(user.getType())) {
+      log.warn("Required field 'type' was not populated for existing user with id: {} in tenant: {}", user.getId(), tenantId);
     }
     return syncUser;
   }

--- a/src/main/resources/swagger.api/schemas/tenant.yaml
+++ b/src/main/resources/swagger.api/schemas/tenant.yaml
@@ -5,8 +5,8 @@ Tenant:
       type: string
     code:
       type: string
-      minLength: 3
-      maxLength: 3
+      minLength: 2
+      maxLength: 5
       pattern: "^[a-zA-Z0-9]*$"
     name:
       type: string

--- a/src/test/java/org/folio/consortia/service/UserAffiliationServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserAffiliationServiceTest.java
@@ -26,11 +26,9 @@ import org.folio.consortia.domain.dto.PrimaryAffiliationEvent;
 import org.folio.consortia.domain.entity.UserTenantEntity;
 import org.folio.consortia.repository.TenantRepository;
 import org.folio.consortia.service.impl.UserAffiliationServiceImpl;
-import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.integration.XOkapiHeaders;
-import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,14 +79,9 @@ class UserAffiliationServiceTest {
 
     when(tenantService.getByTenantId(anyString())).thenReturn(te);
     doNothing().when(consortiumService).checkConsortiumExistsOrThrow(any());
-    when(folioExecutionContext.getTenantId()).thenReturn("diku");
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    when(folioExecutionContext.getOkapiHeaders()).thenReturn(map);
+    mockOkapiHeaders();
 
-    folioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, map);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
-    }
+    userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
 
     verify(primaryAffiliationService, times(1)).createPrimaryAffiliation(any(), anyString(), any(), any());
 
@@ -100,14 +93,9 @@ class UserAffiliationServiceTest {
 
     when(tenantService.getByTenantId(anyString())).thenReturn(te);
     doNothing().when(consortiumService).checkConsortiumExistsOrThrow(any());
-    when(folioExecutionContext.getTenantId()).thenReturn("diku");
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    when(folioExecutionContext.getOkapiHeaders()).thenReturn(map);
+    mockOkapiHeaders();
 
-    folioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, map);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
-    }
+    userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
 
     verify(primaryAffiliationService, times(1)).createPrimaryAffiliation(any(), anyString(), any(), any());
   }
@@ -115,12 +103,10 @@ class UserAffiliationServiceTest {
   @Test
   void tenantNotInConsortiaWhenCreatingTest() {
     when(tenantRepository.findById(anyString())).thenReturn(null);
+    mockOkapiHeaders();
 
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    folioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, map);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
-    }
+    userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
+
     verify(kafkaService, times(0)).send(any(), anyString(), any());
   }
 
@@ -130,12 +116,10 @@ class UserAffiliationServiceTest {
 
     when(tenantService.getByTenantId(anyString())).thenReturn(te);
     when(userTenantService.checkUserIfHasPrimaryAffiliationByUserId(any(), anyString())).thenReturn(true);
+    mockOkapiHeaders();
 
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    folioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, map);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
-    }
+    userAffiliationService.createPrimaryUserAffiliation(userCreatedEventSample);
+
     verify(kafkaService, times(0)).send(any(), anyString(), any());
   }
 
@@ -155,20 +139,12 @@ class UserAffiliationServiceTest {
     var te = createTenantEntity();
 
     when(tenantService.getByTenantId(anyString())).thenReturn(te);
-    when(userTenantService.checkUserIfHasPrimaryAffiliationByUserId(te.getConsortiumId(), userTenant.getUserId().toString()))
-      .thenReturn(true);
+    when(userTenantService.checkUserIfHasPrimaryAffiliationByUserId(te.getConsortiumId(), userTenant.getUserId().toString())).thenReturn(true);
     doNothing().when(consortiumService).checkConsortiumExistsOrThrow(any());
-    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
-    when(folioExecutionContext.getTenantId()).thenReturn("diku");
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    when(folioExecutionContext.getOkapiHeaders()).thenReturn(map);
-
     when(userTenantService.getByUserIdAndTenantId(any(), anyString())).thenReturn(userTenant);
+    mockOkapiHeaders();
 
-    folioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, map);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.updatePrimaryUserAffiliation(userUpdatedEventSample);
-    }
+    userAffiliationService.updatePrimaryUserAffiliation(userUpdatedEventSample);
 
     verify(kafkaService, times(1)).send(any(), anyString(), any());
   }
@@ -180,17 +156,10 @@ class UserAffiliationServiceTest {
     var te = createTenantEntity();
 
     when(tenantService.getByTenantId(anyString())).thenReturn(te);
-    when(userTenantService.checkUserIfHasPrimaryAffiliationByUserId(te.getConsortiumId(), userId))
-      .thenReturn(false);
-    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
-    when(folioExecutionContext.getTenantId()).thenReturn(centralTenantId);
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    when(folioExecutionContext.getOkapiHeaders()).thenReturn(createOkapiHeaders());
+    when(userTenantService.checkUserIfHasPrimaryAffiliationByUserId(te.getConsortiumId(), userId)).thenReturn(false);
+    mockOkapiHeaders();
 
-    folioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, map);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.updatePrimaryUserAffiliation(userUpdatedEventSample);
-    }
+    userAffiliationService.updatePrimaryUserAffiliation(userUpdatedEventSample);
 
     verify(primaryAffiliationService).createPrimaryAffiliation(eq(te.getConsortiumId()), eq(centralTenantId), eq(te), any(PrimaryAffiliationEvent.class));
     verifyNoInteractions(kafkaService);
@@ -208,14 +177,10 @@ class UserAffiliationServiceTest {
     when(userTenantService.checkUserIfHasPrimaryAffiliationByUserId(te.getConsortiumId(), userId.toString()))
       .thenReturn(true);
     doNothing().when(consortiumService).checkConsortiumExistsOrThrow(any());
-    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
-    when(folioExecutionContext.getTenantId()).thenReturn("diku");
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    when(folioExecutionContext.getOkapiHeaders()).thenReturn(map);
     when(userTenantService.deletePrimaryUserTenantAffiliation(any())).thenReturn(true);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.updatePrimaryUserAffiliation(patronUserUpdatedEventSample);
-    }
+    mockOkapiHeaders();
+
+    userAffiliationService.updatePrimaryUserAffiliation(patronUserUpdatedEventSample);
 
     verify(userTenantService).deletePrimaryUserTenantAffiliation(userId);
     verify(userTenantService).deleteShadowUsers(userId);
@@ -235,16 +200,10 @@ class UserAffiliationServiceTest {
 
     when(tenantService.getByTenantId(anyString())).thenReturn(te);
     doNothing().when(consortiumService).checkConsortiumExistsOrThrow(any());
-    when(folioExecutionContext.getTenantId()).thenReturn("diku");
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    when(folioExecutionContext.getOkapiHeaders()).thenReturn(map);
-
     when(userTenantService.deletePrimaryUserTenantAffiliation(any())).thenReturn(true);
+    mockOkapiHeaders();
 
-    folioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, map);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.deletePrimaryUserAffiliation(userDeletedEventSample);
-    }
+    userAffiliationService.deletePrimaryUserAffiliation(userDeletedEventSample);
 
     verify(userTenantService).deletePrimaryUserTenantAffiliation(any());
     verify(userTenantService).deleteShadowUsers(any());
@@ -252,21 +211,15 @@ class UserAffiliationServiceTest {
   }
 
   @Test
-  public void deduplicateDeletePrimaryAffiliationTest() {
+  void deduplicateDeletePrimaryAffiliationTest() {
     var te = createTenantEntity();
 
     when(tenantService.getByTenantId(anyString())).thenReturn(te);
     doNothing().when(consortiumService).checkConsortiumExistsOrThrow(any());
-    when(folioExecutionContext.getTenantId()).thenReturn("diku");
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    when(folioExecutionContext.getOkapiHeaders()).thenReturn(map);
-
     when(userTenantService.deletePrimaryUserTenantAffiliation(any())).thenReturn(false);
+    mockOkapiHeaders();
 
-    folioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, map);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.deletePrimaryUserAffiliation(userDeletedEventSample);
-    }
+    userAffiliationService.deletePrimaryUserAffiliation(userDeletedEventSample);
 
     verify(userTenantService, never()).deleteShadowUsers(any());
     verifyNoInteractions(kafkaService);
@@ -279,15 +232,10 @@ class UserAffiliationServiceTest {
     when(tenantService.getByTenantId(anyString())).thenReturn(te);
     doNothing().when(consortiumService).checkConsortiumExistsOrThrow(any());
     doThrow(new RuntimeException("Unable to send message to Kafka")).when(kafkaService).send(any(), anyString(), any());
-    when(folioExecutionContext.getTenantId()).thenReturn("diku");
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    when(folioExecutionContext.getOkapiHeaders()).thenReturn(map);
-
+    mockOkapiHeaders();
     when(userTenantService.deletePrimaryUserTenantAffiliation(any())).thenReturn(true);
 
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.deletePrimaryUserAffiliation(userDeletedEventSample);
-    }
+    userAffiliationService.deletePrimaryUserAffiliation(userDeletedEventSample);
 
     verify(kafkaService, times(1)).send(any(), anyString(), any());
   }
@@ -295,12 +243,10 @@ class UserAffiliationServiceTest {
   @Test
   void tenantNotInConsortiaWhenDeletingTest() {
     when(tenantRepository.findById(anyString())).thenReturn(null);
+    mockOkapiHeaders();
 
-    Map<String, Collection<String>> map = createOkapiHeaders();
-    folioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, map);
-    try (var fec = new FolioExecutionContextSetter(folioExecutionContext)) {
-      userAffiliationService.deletePrimaryUserAffiliation(userDeletedEventSample);
-    }
+    userAffiliationService.deletePrimaryUserAffiliation(userDeletedEventSample);
+
     verify(kafkaService, times(0)).send(any(), anyString(), any());
   }
 
@@ -309,6 +255,12 @@ class UserAffiliationServiceTest {
     userAffiliationService.deletePrimaryUserAffiliation("wrong event payload");
 
     verifyNoInteractions(kafkaService);
+  }
+
+  private void mockOkapiHeaders() {
+    when(folioExecutionContext.getTenantId()).thenReturn("diku");
+    Map<String, Collection<String>> okapiHeaders = createOkapiHeaders();
+    when(folioExecutionContext.getOkapiHeaders()).thenReturn(okapiHeaders);
   }
 
   private Map<String, Collection<String>> createOkapiHeaders() {

--- a/src/test/resources/mockdata/kafka/update_primary_affiliation_request_patron_user.json
+++ b/src/test/resources/mockdata/kafka/update_primary_affiliation_request_patron_user.json
@@ -1,0 +1,18 @@
+{
+  "id": "03670ef4-3fcc-41d9-98a2-4375b2420f65",
+  "action": "Edit",
+  "tenantId": "diku",
+  "performedBy": "d900646f-4cfe-54fa-b6ac-fd646620eb28",
+  "eventDate": 1681984177363,
+  "actionDate": 1681984177324,
+  "userDto": {
+    "username": "newTestUser",
+    "id": "148f7c24-54fc-4d7f-afff-da2dfcd902e3",
+    "active": true,
+    "type": "patron",
+    "departments": [],
+    "proxyFor": [],
+    "createdDate": 1681984177336,
+    "updatedDate": 1681984177336
+  }
+}


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-101

## Overview:

After adding functionality to not process patron users by consortium pipeline - primary affiliations(and affiliation in central tenant) are not created. 

So now it is possible to change the user type from patron to staff - and the user should be processed by a consortium pipeline in this case.

User Updated event handler in mod-consortia should create primary affiliation(and affiliation with shadow user in central tenant if original user was from member tenant)

## Implementation Approach:

User Updated event handler in mod-consortia should be modified to create primary affiliation(with affiliation in central tenant if user is from member tenant).

It should invoke PrimaryAffiliationService to perform this work.