### PR TITLE
[MODCON - 94] - Add required permissions during setup only for ECS mode

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -373,6 +373,7 @@
         "consortia.user-tenants.item.post",
         "consortia.user-tenants.item.delete",
         "consortia.consortia-configuration.item.post",
+        "consortia.inventory.share.local.instance",
         "consortia.sync-primary-affiliations.item.post",
         "consortia.create-primary-affiliations.item.post",
         "consortia.sharing-instances.item.post",
@@ -475,6 +476,11 @@
       "permissionName": "consortia.consortia-configuration.item.post",
       "displayName": "create consortia configuration",
       "description": "Create consortia configuration"
+    },
+    {
+      "permissionName": "consortia.inventory.share.local.instance",
+      "displayName": "Inventory: Share local instance with consortium",
+      "description": "Inventory: Share local instance with consortium"
     },
     {
       "permissionName": "consortia.sharing-instances.item.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -480,7 +480,8 @@
     {
       "permissionName": "consortia.inventory.share.local.instance",
       "displayName": "Inventory: Share local instance with consortium",
-      "description": "Inventory: Share local instance with consortium"
+      "description": "Inventory: Share local instance with consortium",
+      "visible": true
     },
     {
       "permissionName": "consortia.sharing-instances.item.post",

--- a/src/main/java/org/folio/consortia/client/PermissionsClient.java
+++ b/src/main/java/org/folio/consortia/client/PermissionsClient.java
@@ -13,17 +13,22 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "consortia-perms-client", url = "perms/users", configuration = FeignClientConfiguration.class)
+@FeignClient(name = "consortia-perms-client", url = "perms", configuration = FeignClientConfiguration.class)
 public interface PermissionsClient {
-  @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+  /* Permission User endpoints */
+  @GetMapping(value = "/users", produces = MediaType.APPLICATION_JSON_VALUE)
   PermissionUserCollection get(@RequestParam("query") String query);
 
-  @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PostMapping(value = "/users", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   PermissionUser create(@RequestBody PermissionUser permissionUser);
 
-  @PostMapping(value = "/{userId}/permissions?indexField=userId", consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PostMapping(value = "/users/{userId}/permissions?indexField=userId", consumes = MediaType.APPLICATION_JSON_VALUE)
   void addPermission(@PathVariable("userId") String userId, Permission permission);
 
-  @DeleteMapping(value = "/{id}")
+  @DeleteMapping(value = "/users/{id}")
   void deletePermissionUser(@PathVariable("id") String id);
+
+  /* Permission endpoints */
+  @PostMapping(value = "/permissions", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  void createPermission(@RequestBody Permission permission);
 }

--- a/src/main/java/org/folio/consortia/domain/dto/Permission.java
+++ b/src/main/java/org/folio/consortia/domain/dto/Permission.java
@@ -1,4 +1,18 @@
 package org.folio.consortia.domain.dto;
 
-public record Permission(String permissionName) {
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Permission {
+  private String permissionName;
+  private String displayName;
+  private String description;
+
+  public Permission(String permissionName) {
+    this.permissionName = permissionName;
+  }
 }

--- a/src/main/java/org/folio/consortia/service/PermissionService.java
+++ b/src/main/java/org/folio/consortia/service/PermissionService.java
@@ -1,0 +1,10 @@
+package org.folio.consortia.service;
+
+public interface PermissionService {
+
+  /**
+   * Create new permission
+   * @param permissionName name of permission
+   */
+  void createPermission(String permissionName);
+}

--- a/src/main/java/org/folio/consortia/service/PermissionService.java
+++ b/src/main/java/org/folio/consortia/service/PermissionService.java
@@ -1,10 +1,12 @@
 package org.folio.consortia.service;
 
+import org.folio.consortia.domain.dto.Permission;
+
 public interface PermissionService {
 
   /**
    * Create new permission
-   * @param permissionName name of permission
+   * @param permission permission object
    */
-  void createPermission(String permissionName);
+  void createPermission(Permission permission);
 }

--- a/src/main/java/org/folio/consortia/service/impl/PermissionServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PermissionServiceImpl.java
@@ -16,8 +16,7 @@ public class PermissionServiceImpl implements PermissionService {
   private final PermissionsClient permissionsClient;
 
   @Override
-  public void createPermission(String permissionName) {
-    Permission permission = new Permission(permissionName);
+  public void createPermission(Permission permission) {
     permissionsClient.createPermission(permission);
   }
 }

--- a/src/main/java/org/folio/consortia/service/impl/PermissionServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PermissionServiceImpl.java
@@ -1,0 +1,23 @@
+package org.folio.consortia.service.impl;
+
+import org.folio.consortia.client.PermissionsClient;
+import org.folio.consortia.domain.dto.Permission;
+import org.folio.consortia.service.PermissionService;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class PermissionServiceImpl implements PermissionService {
+
+  private final PermissionsClient permissionsClient;
+
+  @Override
+  public void createPermission(String permissionName) {
+    Permission permission = new Permission(permissionName);
+    permissionsClient.createPermission(permission);
+  }
+}

--- a/src/main/java/org/folio/consortia/service/impl/SharingSettingServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SharingSettingServiceImpl.java
@@ -2,6 +2,7 @@ package org.folio.consortia.service.impl;
 
 import static org.folio.consortia.utils.HelperUtils.CONSORTIUM_SETTING_SOURCE;
 import static org.folio.consortia.utils.HelperUtils.LOCAL_SETTING_SOURCE;
+import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.getRunnableWithCurrentFolioContext;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -149,14 +150,14 @@ public class SharingSettingServiceImpl implements SharingSettingService {
       sharingSettingDeleteResponse = new SharingSettingDeleteResponse()
         .pcId(pcId);
     }
-    asyncTaskExecutor.execute(() -> {
+    asyncTaskExecutor.execute(getRunnableWithCurrentFolioContext(() -> {
       try {
         updateSettingsForFailedTenants(consortiumId, pcId, sharingSettingRequest);
       } catch (InterruptedException e) {
         log.error("Thread sleep was interrupted", e);
         Thread.currentThread().interrupt();
       }
-    });
+    }));
     return sharingSettingDeleteResponse;
   }
 

--- a/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
@@ -32,6 +32,7 @@ import org.folio.consortia.repository.UserTenantRepository;
 import org.folio.consortia.service.CleanupService;
 import org.folio.consortia.service.ConsortiumService;
 import org.folio.consortia.service.LockService;
+import org.folio.consortia.service.PermissionService;
 import org.folio.consortia.service.PermissionUserService;
 import org.folio.consortia.service.TenantService;
 import org.folio.consortia.service.UserService;
@@ -69,6 +70,7 @@ public class TenantServiceImpl implements TenantService {
   private final ConsortiumService consortiumService;
   private final FolioExecutionContext folioExecutionContext;
   private final ConsortiaConfigurationClient configurationClient;
+  private final PermissionService permissionService;
   private final PermissionUserService permissionUserService;
   private final UserService userService;
   private final FolioExecutionContextHelper contextHelper;
@@ -164,6 +166,8 @@ public class TenantServiceImpl implements TenantService {
         createShadowUserWithPermissions(shadowSystemUser, SHADOW_SYSTEM_USER_PERMISSION_FILE_PATH);
         log.info("save:: shadow system user '{}' with permissions was created in tenant '{}'", shadowSystemUser.getId(), tenantDto.getId());
       }
+      // create permission consortia.consortia-configuration.
+      permissionService.createPermission("consortia.consortia-configuration.item.post");
       syncPrimaryAffiliationClient.syncPrimaryAffiliations(consortiumId.toString(), tenantDto.getId(), centralTenantId);
     }
     log.info("save:: saved consortia configuration with centralTenantId={} by tenantId={} context", centralTenantId, tenantDto.getId());

--- a/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
@@ -14,6 +14,7 @@ import org.folio.consortia.client.SyncPrimaryAffiliationClient;
 import org.folio.consortia.client.UserTenantsClient;
 import org.folio.consortia.config.FolioExecutionContextHelper;
 import org.folio.consortia.domain.dto.ConsortiaConfiguration;
+import org.folio.consortia.domain.dto.Permission;
 import org.folio.consortia.domain.dto.PermissionUser;
 import org.folio.consortia.domain.dto.Tenant;
 import org.folio.consortia.domain.dto.TenantCollection;
@@ -166,8 +167,8 @@ public class TenantServiceImpl implements TenantService {
         createShadowUserWithPermissions(shadowSystemUser, SHADOW_SYSTEM_USER_PERMISSION_FILE_PATH);
         log.info("save:: shadow system user '{}' with permissions was created in tenant '{}'", shadowSystemUser.getId(), tenantDto.getId());
       }
-      // create permission consortia.consortia-configuration.
-      permissionService.createPermission("consortia.consortia-configuration.item.post");
+      // create consortia configuration for ECS mode
+      createConfigurationPermission();
       syncPrimaryAffiliationClient.syncPrimaryAffiliations(consortiumId.toString(), tenantDto.getId(), centralTenantId);
     }
     log.info("save:: saved consortia configuration with centralTenantId={} by tenantId={} context", centralTenantId, tenantDto.getId());
@@ -322,6 +323,15 @@ public class TenantServiceImpl implements TenantService {
     ConsortiaConfiguration configuration = new ConsortiaConfiguration();
     configuration.setCentralTenantId(tenantId);
     return configuration;
+  }
+
+  private void createConfigurationPermission() {
+    log.info("createConfigurationPermission:: Creating permission for inventory sharing instance");
+    Permission permission = new Permission();
+    permission.setPermissionName("consortia.inventory.share.local.instance");
+    permission.setDisplayName("Inventory: Share local instance with consortium");
+    permission.setDescription("Inventory: Share local instance with consortium");
+    permissionService.createPermission(permission);
   }
 
   private void createShadowUserWithPermissions(User user, String permissionFilePath) {

--- a/src/main/resources/permissions/system-user-permissions.csv
+++ b/src/main/resources/permissions/system-user-permissions.csv
@@ -10,6 +10,7 @@ perms.users.item.delete
 perms.users.assign.immutable
 perms.users.assign.mutable
 perms.users.get
+perms.permissions.item.post
 user-tenants.item.post
 consortia.sync-primary-affiliations.item.post
 consortia.create-primary-affiliations.item.post

--- a/src/main/resources/swagger.api/schemas/tenant.yaml
+++ b/src/main/resources/swagger.api/schemas/tenant.yaml
@@ -5,8 +5,8 @@ Tenant:
       type: string
     code:
       type: string
-      minLength: 3
-      maxLength: 3
+      minLength: 2
+      maxLength: 5
       pattern: "^[a-zA-Z0-9]*$"
     name:
       type: string

--- a/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.folio.consortia.exception.ResourceNotFoundException.NOT_FOUND_MSG_TEMPLATE;
 import static org.folio.consortia.utils.EntityUtils.createConsortiaConfiguration;
+import static org.folio.consortia.utils.EntityUtils.createInventoryInstanceSharingPermission;
 import static org.folio.consortia.utils.EntityUtils.createTenant;
 import static org.folio.consortia.utils.EntityUtils.createTenantDetailsEntity;
 import static org.folio.consortia.utils.EntityUtils.createTenantEntity;
@@ -152,6 +153,7 @@ class TenantControllerTest extends BaseIT {
     permissionUserCollection.setPermissionUsers(List.of(permissionUser));
     User adminUser = createUser("diku_admin");
     User systemUser = createUser("consortia-system-user");
+    var consortiaConfigurationPermission = createInventoryInstanceSharingPermission();
 
     var tenantDetailsEntity = new TenantDetailsEntity();
     tenantDetailsEntity.setConsortiumId(centralTenant.getConsortiumId());
@@ -171,7 +173,7 @@ class TenantControllerTest extends BaseIT {
     doReturn(new User()).when(usersClient).getUsersByUserId(any());
     doReturn(permissionUserCollection).when(permissionsClient).get(anyString());
     doNothing().when(permissionsClient).addPermission(anyString(), any());
-    doNothing().when(permissionService).createPermission(any());
+    doNothing().when(permissionsClient).createPermission(consortiaConfigurationPermission);
     when(consortiumRepository.existsById(any())).thenReturn(true);
     when(tenantRepository.existsById(any())).thenReturn(false);
     when(tenantDetailsRepository.save(any(TenantDetailsEntity.class))).thenReturn(tenantDetailsEntity);

--- a/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
@@ -171,7 +171,7 @@ class TenantControllerTest extends BaseIT {
     doReturn(new User()).when(usersClient).getUsersByUserId(any());
     doReturn(permissionUserCollection).when(permissionsClient).get(anyString());
     doNothing().when(permissionsClient).addPermission(anyString(), any());
-    doNothing().when(permissionService).createPermission("consortia.consortia-configuration.item.post");
+    doNothing().when(permissionService).createPermission(any());
     when(consortiumRepository.existsById(any())).thenReturn(true);
     when(tenantRepository.existsById(any())).thenReturn(false);
     when(tenantDetailsRepository.save(any(TenantDetailsEntity.class))).thenReturn(tenantDetailsEntity);

--- a/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
@@ -52,6 +52,7 @@ import org.folio.consortia.repository.ConsortiumRepository;
 import org.folio.consortia.repository.TenantDetailsRepository;
 import org.folio.consortia.repository.TenantRepository;
 import org.folio.consortia.repository.UserTenantRepository;
+import org.folio.consortia.service.PermissionService;
 import org.folio.consortia.service.TenantService;
 import org.folio.consortia.service.UserService;
 import org.folio.consortia.service.UserTenantService;
@@ -110,6 +111,8 @@ class TenantControllerTest extends BaseIT {
   FolioExecutionContext folioExecutionContext = new FolioExecutionContext() {};
   @Mock
   PermissionsClient permissionsClient;
+  @Mock
+  PermissionService permissionService;
   @MockBean
   UserTenantsClient userTenantsClient;
   @MockBean
@@ -168,6 +171,7 @@ class TenantControllerTest extends BaseIT {
     doReturn(new User()).when(usersClient).getUsersByUserId(any());
     doReturn(permissionUserCollection).when(permissionsClient).get(anyString());
     doNothing().when(permissionsClient).addPermission(anyString(), any());
+    doNothing().when(permissionService).createPermission("consortia.consortia-configuration.item.post");
     when(consortiumRepository.existsById(any())).thenReturn(true);
     when(tenantRepository.existsById(any())).thenReturn(false);
     when(tenantDetailsRepository.save(any(TenantDetailsEntity.class))).thenReturn(tenantDetailsEntity);

--- a/src/test/java/org/folio/consortia/service/PermissionServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/PermissionServiceTest.java
@@ -1,20 +1,13 @@
 package org.folio.consortia.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.folio.consortia.utils.EntityUtils.RANDOM_USER_ID;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.util.List;
-import java.util.UUID;
-
 import org.folio.consortia.client.PermissionsClient;
-import org.folio.consortia.domain.dto.PermissionUser;
-import org.folio.consortia.service.impl.PermissionUserServiceImpl;
-import org.junit.jupiter.api.Assertions;
+import org.folio.consortia.domain.dto.Permission;
+import org.folio.consortia.service.impl.PermissionServiceImpl;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -24,49 +17,20 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 @EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
 class PermissionServiceTest {
-  private static final String PERMISSIONS_FILE_PATH = "permissions/test-user-permissions.csv";
-  private static final String EMPTY_PERMISSIONS_FILE_PATH = "permissions/test-user--empty-permissions.csv";
   @InjectMocks
-  PermissionUserServiceImpl permissionUserService;
+  PermissionServiceImpl permissionService;
   @Mock
   PermissionsClient permissionsClient;
 
   @Test
-  void shouldThrowErrorForEmptyPermissionFileWhileAdding() {
-    PermissionUser permissionUser = PermissionUser.of(UUID.randomUUID().toString(), RANDOM_USER_ID, List.of());
+  void shouldCreatePermission() {
+    String permissionName = "consortia.consortia-configuration.item.post";
+    Permission permission = new Permission(permissionName);
 
-    Assertions.assertThrows(java.lang.IllegalStateException.class, () -> permissionUserService.addPermissions(permissionUser, EMPTY_PERMISSIONS_FILE_PATH));
+    doNothing().when(permissionsClient).createPermission(permission);
+
+    permissionService.createPermission(permissionName);
+
+    verify(permissionService, times(1)).createPermission(permissionName);
   }
-
-  @Test
-  void shouldThrowErrorForEmptyPermissionFileWhileCreating() {
-    Assertions.assertThrows(java.lang.IllegalStateException.class, () -> permissionUserService.createWithPermissionsFromFile(UUID.randomUUID().toString(), EMPTY_PERMISSIONS_FILE_PATH));
-  }
-
-  @Test
-  void shouldAddPermissionsToPermissionUser() {
-    PermissionUser permissionUser = PermissionUser.of(UUID.randomUUID().toString(), RANDOM_USER_ID, List.of());
-
-    doNothing().when(permissionsClient).addPermission(any(),any());
-    Assertions.assertDoesNotThrow(() -> permissionUserService.addPermissions(permissionUser, PERMISSIONS_FILE_PATH));
-  }
-
-  @Test
-  void shouldCreateEmptyPermission() {
-    String userId = RANDOM_USER_ID;
-    ArgumentCaptor<PermissionUser> captor = ArgumentCaptor.forClass(PermissionUser.class);
-    permissionUserService.createWithEmptyPermissions(userId);
-    verify(permissionsClient).create(captor.capture());
-    PermissionUser created = captor.getValue();
-    assertThat(created.getUserId()).isEqualTo(userId);
-    assertThat(created.getPermissions()).isEmpty();
-  }
-
-  @Test
-  void shouldDeletePermissionUser() {
-    String permissionUserId = UUID.randomUUID().toString();
-    permissionUserService.deletePermissionUser(permissionUserId);
-    verify(permissionsClient).deletePermissionUser(permissionUserId);
-  }
-
 }

--- a/src/test/java/org/folio/consortia/service/PermissionServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/PermissionServiceTest.java
@@ -1,7 +1,6 @@
 package org.folio.consortia.service;
 
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.folio.consortia.client.PermissionsClient;
@@ -24,13 +23,15 @@ class PermissionServiceTest {
 
   @Test
   void shouldCreatePermission() {
-    String permissionName = "consortia.consortia-configuration.item.post";
-    Permission permission = new Permission(permissionName);
+    Permission permission = new Permission();
+    permission.setPermissionName("consortia.inventory.share.local.instance");
+    permission.setDisplayName("Inventory: Share local instance with consortium");
+    permission.setDescription("Inventory: Share local instance with consortium");
 
     doNothing().when(permissionsClient).createPermission(permission);
 
     permissionService.createPermission(permission);
 
-    verify(permissionService, times(1)).createPermission(permission);
+    verify(permissionsClient).createPermission(permission);
   }
 }

--- a/src/test/java/org/folio/consortia/service/PermissionServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/PermissionServiceTest.java
@@ -29,8 +29,8 @@ class PermissionServiceTest {
 
     doNothing().when(permissionsClient).createPermission(permission);
 
-    permissionService.createPermission(permissionName);
+    permissionService.createPermission(permission);
 
-    verify(permissionService, times(1)).createPermission(permissionName);
+    verify(permissionService, times(1)).createPermission(permission);
   }
 }

--- a/src/test/java/org/folio/consortia/service/PermissionUserServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/PermissionUserServiceTest.java
@@ -1,0 +1,72 @@
+package org.folio.consortia.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.consortia.utils.EntityUtils.RANDOM_USER_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.folio.consortia.client.PermissionsClient;
+import org.folio.consortia.domain.dto.PermissionUser;
+import org.folio.consortia.service.impl.PermissionUserServiceImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+class PermissionUserServiceTest {
+  private static final String PERMISSIONS_FILE_PATH = "permissions/test-user-permissions.csv";
+  private static final String EMPTY_PERMISSIONS_FILE_PATH = "permissions/test-user--empty-permissions.csv";
+  @InjectMocks
+  PermissionUserServiceImpl permissionUserService;
+  @Mock
+  PermissionsClient permissionsClient;
+
+  @Test
+  void shouldThrowErrorForEmptyPermissionFileWhileAdding() {
+    PermissionUser permissionUser = PermissionUser.of(UUID.randomUUID().toString(), RANDOM_USER_ID, List.of());
+
+    Assertions.assertThrows(java.lang.IllegalStateException.class, () -> permissionUserService.addPermissions(permissionUser, EMPTY_PERMISSIONS_FILE_PATH));
+  }
+
+  @Test
+  void shouldThrowErrorForEmptyPermissionFileWhileCreating() {
+    Assertions.assertThrows(java.lang.IllegalStateException.class, () -> permissionUserService.createWithPermissionsFromFile(UUID.randomUUID().toString(), EMPTY_PERMISSIONS_FILE_PATH));
+  }
+
+  @Test
+  void shouldAddPermissionsToPermissionUser() {
+    PermissionUser permissionUser = PermissionUser.of(UUID.randomUUID().toString(), RANDOM_USER_ID, List.of());
+
+    doNothing().when(permissionsClient).addPermission(any(),any());
+    Assertions.assertDoesNotThrow(() -> permissionUserService.addPermissions(permissionUser, PERMISSIONS_FILE_PATH));
+  }
+
+  @Test
+  void shouldCreateEmptyPermission() {
+    String userId = RANDOM_USER_ID;
+    ArgumentCaptor<PermissionUser> captor = ArgumentCaptor.forClass(PermissionUser.class);
+    permissionUserService.createWithEmptyPermissions(userId);
+    verify(permissionsClient).create(captor.capture());
+    PermissionUser created = captor.getValue();
+    assertThat(created.getUserId()).isEqualTo(userId);
+    assertThat(created.getPermissions()).isEmpty();
+  }
+
+  @Test
+  void shouldDeletePermissionUser() {
+    String permissionUserId = UUID.randomUUID().toString();
+    permissionUserService.deletePermissionUser(permissionUserId);
+    verify(permissionsClient).deletePermissionUser(permissionUserId);
+  }
+
+}

--- a/src/test/java/org/folio/consortia/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantServiceTest.java
@@ -108,7 +108,7 @@ class TenantServiceTest {
   @Mock
   private PermissionUserService permissionUserService;
   @Mock
-  private PermissionUserService permissionService;
+  private PermissionService permissionService;
   @Mock
   private UserService userService;
   @Mock
@@ -178,6 +178,7 @@ class TenantServiceTest {
     when(userService.getById(any())).thenReturn(new User());
     when(permissionsClient.get(any())).thenReturn(permissionUserCollection);
     when(permissionsClient.create(any())).thenReturn(PermissionUser.of(UUID.randomUUID().toString(), adminUser.getId(), List.of("users.collection.get")));
+    doNothing().when(permissionService).createPermission("consortia.consortia-configuration.item.post");
     when(tenantRepository.existsById(any())).thenReturn(false);
     when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(centralTenant));
     when(tenantDetailsRepository.save(any(TenantDetailsEntity.class))).thenReturn(localTenantDetailsEntity);
@@ -219,6 +220,7 @@ class TenantServiceTest {
     when(consortiumRepository.existsById(consortiumId)).thenReturn(true);
     when(userService.prepareShadowUser(any(), any())).thenReturn(user);
     when(permissionsClient.get(any())).thenReturn(permissionUserCollection);
+    doNothing().when(permissionService).createPermission("consortia.consortia-configuration.item.post");
     doNothing().when(permissionsClient).addPermission(any(), any());
     when(tenantRepository.existsById(any())).thenReturn(false);
     when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(centralTenant));

--- a/src/test/java/org/folio/consortia/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantServiceTest.java
@@ -178,7 +178,7 @@ class TenantServiceTest {
     when(userService.getById(any())).thenReturn(new User());
     when(permissionsClient.get(any())).thenReturn(permissionUserCollection);
     when(permissionsClient.create(any())).thenReturn(PermissionUser.of(UUID.randomUUID().toString(), adminUser.getId(), List.of("users.collection.get")));
-    doNothing().when(permissionService).createPermission("consortia.consortia-configuration.item.post");
+    doNothing().when(permissionService).createPermission(any());
     when(tenantRepository.existsById(any())).thenReturn(false);
     when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(centralTenant));
     when(tenantDetailsRepository.save(any(TenantDetailsEntity.class))).thenReturn(localTenantDetailsEntity);
@@ -220,7 +220,7 @@ class TenantServiceTest {
     when(consortiumRepository.existsById(consortiumId)).thenReturn(true);
     when(userService.prepareShadowUser(any(), any())).thenReturn(user);
     when(permissionsClient.get(any())).thenReturn(permissionUserCollection);
-    doNothing().when(permissionService).createPermission("consortia.consortia-configuration.item.post");
+    doNothing().when(permissionService).createPermission(any());
     doNothing().when(permissionsClient).addPermission(any(), any());
     when(tenantRepository.existsById(any())).thenReturn(false);
     when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(centralTenant));

--- a/src/test/java/org/folio/consortia/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantServiceTest.java
@@ -1,6 +1,7 @@
 package org.folio.consortia.service;
 
 import static org.folio.consortia.utils.EntityUtils.createConsortiaConfiguration;
+import static org.folio.consortia.utils.EntityUtils.createInventoryInstanceSharingPermission;
 import static org.folio.consortia.utils.EntityUtils.createTenant;
 import static org.folio.consortia.utils.EntityUtils.createTenantDetailsEntity;
 import static org.folio.consortia.utils.EntityUtils.createTenantEntity;
@@ -178,7 +179,7 @@ class TenantServiceTest {
     when(userService.getById(any())).thenReturn(new User());
     when(permissionsClient.get(any())).thenReturn(permissionUserCollection);
     when(permissionsClient.create(any())).thenReturn(PermissionUser.of(UUID.randomUUID().toString(), adminUser.getId(), List.of("users.collection.get")));
-    doNothing().when(permissionService).createPermission(any());
+    doNothing().when(permissionService).createPermission(createInventoryInstanceSharingPermission());
     when(tenantRepository.existsById(any())).thenReturn(false);
     when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(centralTenant));
     when(tenantDetailsRepository.save(any(TenantDetailsEntity.class))).thenReturn(localTenantDetailsEntity);
@@ -220,7 +221,7 @@ class TenantServiceTest {
     when(consortiumRepository.existsById(consortiumId)).thenReturn(true);
     when(userService.prepareShadowUser(any(), any())).thenReturn(user);
     when(permissionsClient.get(any())).thenReturn(permissionUserCollection);
-    doNothing().when(permissionService).createPermission(any());
+    doNothing().when(permissionService).createPermission(createInventoryInstanceSharingPermission());
     doNothing().when(permissionsClient).addPermission(any(), any());
     when(tenantRepository.existsById(any())).thenReturn(false);
     when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(centralTenant));

--- a/src/test/java/org/folio/consortia/utils/EntityUtils.java
+++ b/src/test/java/org/folio/consortia/utils/EntityUtils.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import org.folio.consortia.domain.dto.ConsortiaConfiguration;
 import org.folio.consortia.domain.dto.Consortium;
+import org.folio.consortia.domain.dto.Permission;
 import org.folio.consortia.domain.dto.Personal;
 import org.folio.consortia.domain.dto.PublicationDetailsResponse;
 import org.folio.consortia.domain.dto.PublicationRequest;
@@ -315,5 +316,13 @@ public class EntityUtils {
     user.setPersonal(personal);
     user.setActive(true);
     return user;
+  }
+
+  public static Permission createInventoryInstanceSharingPermission() {
+    var permission = new Permission();
+    permission.setPermissionName("consortia.inventory.share.local.instance");
+    permission.setDisplayName("Inventory: Share local instance with consortium");
+    permission.setDescription("Inventory: Share local instance with consortium");
+    return permission;
   }
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODCONSORTIA-01 Logging Improvement
  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
https://issues.folio.org/browse/MODCON-94
## Approach
Created a new permission called consortia.inventory.share.local.instance and made it as visible true
Every time we are saving tenants, we will create this permission to these tenants' permission schemes
#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
-->
