### PR TITLE
[MODCON-94] - Add required permissions during setup only for ECS mode

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -373,6 +373,7 @@
         "consortia.user-tenants.item.post",
         "consortia.user-tenants.item.delete",
         "consortia.consortia-configuration.item.post",
+        "consortia.inventory.share.local.instance",
         "consortia.sync-primary-affiliations.item.post",
         "consortia.create-primary-affiliations.item.post",
         "consortia.sharing-instances.item.post",
@@ -475,6 +476,12 @@
       "permissionName": "consortia.consortia-configuration.item.post",
       "displayName": "create consortia configuration",
       "description": "Create consortia configuration"
+    },
+    {
+      "permissionName": "consortia.inventory.share.local.instance",
+      "displayName": "Inventory: Share local instance with consortium",
+      "description": "Inventory: Share local instance with consortium",
+      "visible": true
     },
     {
       "permissionName": "consortia.sharing-instances.item.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -481,6 +481,9 @@
       "permissionName": "consortia.inventory.share.local.instance",
       "displayName": "Inventory: Share local instance with consortium",
       "description": "Inventory: Share local instance with consortium",
+      "subPermissions": [
+        "consortia.sharing-instances.item.post"
+      ],
       "visible": true
     },
     {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODCONSORTIA-01 Logging Improvement
  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
https://issues.folio.org/browse/MODCON-94
## Approach
Created a new permission called consortia.inventory.share.local.instance and made it as visible true