### PR TITLE
[MODCON - 94] - Context change from any tenant to central tenant

### DIFF
--- a/src/main/java/org/folio/consortia/controller/SharingInstanceController.java
+++ b/src/main/java/org/folio/consortia/controller/SharingInstanceController.java
@@ -1,5 +1,6 @@
 package org.folio.consortia.controller;
 
+import static org.folio.consortia.utils.TenantContextUtils.prepareContextForTenant;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import java.util.UUID;
@@ -9,6 +10,10 @@ import org.folio.consortia.domain.dto.SharingInstanceCollection;
 import org.folio.consortia.domain.dto.Status;
 import org.folio.consortia.rest.resource.InstancesApi;
 import org.folio.consortia.service.SharingInstanceService;
+import org.folio.consortia.service.TenantService;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,10 +29,18 @@ import lombok.extern.log4j.Log4j2;
 public class SharingInstanceController implements InstancesApi {
 
   private final SharingInstanceService sharingInstanceService;
+  private final TenantService tenantService;
+  private final FolioModuleMetadata folioModuleMetadata;
+  private final FolioExecutionContext folioExecutionContext;
 
   @Override
   public ResponseEntity<SharingInstance> startSharingInstance(UUID consortiumId, @Validated SharingInstance sharingInstance) {
-    return ResponseEntity.status(CREATED).body(sharingInstanceService.start(consortiumId, sharingInstance));
+    SharingInstance sharedInstance;
+    var centralTenantId = tenantService.getCentralTenantId();
+    try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(centralTenantId, folioModuleMetadata, folioExecutionContext))) {
+     sharedInstance = sharingInstanceService.start(consortiumId, sharingInstance);
+    }
+    return ResponseEntity.status(CREATED).body(sharedInstance);
   }
 
   @Override

--- a/src/main/java/org/folio/consortia/controller/SharingInstanceController.java
+++ b/src/main/java/org/folio/consortia/controller/SharingInstanceController.java
@@ -9,8 +9,8 @@ import org.folio.consortia.domain.dto.SharingInstance;
 import org.folio.consortia.domain.dto.SharingInstanceCollection;
 import org.folio.consortia.domain.dto.Status;
 import org.folio.consortia.rest.resource.InstancesApi;
+import org.folio.consortia.service.ConsortiaConfigurationService;
 import org.folio.consortia.service.SharingInstanceService;
-import org.folio.consortia.service.TenantService;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.scope.FolioExecutionContextSetter;
@@ -29,14 +29,14 @@ import lombok.extern.log4j.Log4j2;
 public class SharingInstanceController implements InstancesApi {
 
   private final SharingInstanceService sharingInstanceService;
-  private final TenantService tenantService;
+  private final ConsortiaConfigurationService configurationService;
   private final FolioModuleMetadata folioModuleMetadata;
   private final FolioExecutionContext folioExecutionContext;
 
   @Override
   public ResponseEntity<SharingInstance> startSharingInstance(UUID consortiumId, @Validated SharingInstance sharingInstance) {
     SharingInstance sharedInstance;
-    var centralTenantId = tenantService.getCentralTenantId();
+    var centralTenantId = configurationService.getCentralTenantId(folioExecutionContext.getTenantId());
     try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(centralTenantId, folioModuleMetadata, folioExecutionContext))) {
      sharedInstance = sharingInstanceService.start(consortiumId, sharingInstance);
     }

--- a/src/main/java/org/folio/consortia/controller/SharingInstanceController.java
+++ b/src/main/java/org/folio/consortia/controller/SharingInstanceController.java
@@ -35,12 +35,11 @@ public class SharingInstanceController implements InstancesApi {
 
   @Override
   public ResponseEntity<SharingInstance> startSharingInstance(UUID consortiumId, @Validated SharingInstance sharingInstance) {
-    SharingInstance sharedInstance;
     var centralTenantId = configurationService.getCentralTenantId(folioExecutionContext.getTenantId());
     try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(centralTenantId, folioModuleMetadata, folioExecutionContext))) {
-     sharedInstance = sharingInstanceService.start(consortiumId, sharingInstance);
+     var sharedInstance = sharingInstanceService.start(consortiumId, sharingInstance);
+     return ResponseEntity.status(CREATED).body(sharedInstance);
     }
-    return ResponseEntity.status(CREATED).body(sharedInstance);
   }
 
   @Override

--- a/src/main/java/org/folio/consortia/service/impl/SharingSettingServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SharingSettingServiceImpl.java
@@ -2,6 +2,7 @@ package org.folio.consortia.service.impl;
 
 import static org.folio.consortia.utils.HelperUtils.CONSORTIUM_SETTING_SOURCE;
 import static org.folio.consortia.utils.HelperUtils.LOCAL_SETTING_SOURCE;
+import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.getRunnableWithCurrentFolioContext;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -149,14 +150,14 @@ public class SharingSettingServiceImpl implements SharingSettingService {
       sharingSettingDeleteResponse = new SharingSettingDeleteResponse()
         .pcId(pcId);
     }
-    asyncTaskExecutor.execute(() -> {
+    asyncTaskExecutor.execute(getRunnableWithCurrentFolioContext(() -> {
       try {
         updateSettingsForFailedTenants(consortiumId, pcId, sharingSettingRequest);
       } catch (InterruptedException e) {
         log.error("Thread sleep was interrupted", e);
         Thread.currentThread().interrupt();
       }
-    });
+    }));
     return sharingSettingDeleteResponse;
   }
 

--- a/src/main/java/org/folio/consortia/service/impl/SharingSettingServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SharingSettingServiceImpl.java
@@ -202,10 +202,8 @@ public class SharingSettingServiceImpl implements SharingSettingService {
     publicationPutRequest.setPayload(updatedPayload);
     publicationPutRequest.setTenants(failedTenantList);
 
-    try (var ignored = new FolioExecutionContextSetter(contextHelper.getSystemUserFolioExecutionContext(folioExecutionContext.getTenantId()))) {
-      log.info("send PUT request to publication with new source in payload={} by system user of {}", LOCAL_SETTING_SOURCE, folioExecutionContext.getTenantId());
-      publishRequest(consortiumId, publicationPutRequest);
-    }
+    log.info("send PUT request to publication with new source in payload={} by system user of {}", LOCAL_SETTING_SOURCE, folioExecutionContext.getTenantId());
+    publishRequest(consortiumId, publicationPutRequest);
   }
 
   private void validateSharingSettingRequestOrThrow(UUID settingId, SharingSettingRequest sharingSettingRequest) {

--- a/src/test/java/org/folio/consortia/controller/SharingInstanceControllerIntegrationTests.java
+++ b/src/test/java/org/folio/consortia/controller/SharingInstanceControllerIntegrationTests.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 
 import org.folio.consortia.repository.ConsortiumRepository;
 import org.folio.consortia.repository.TenantRepository;
+import org.folio.consortia.service.ConsortiaConfigurationService;
 import org.folio.consortia.service.TenantService;
 import org.folio.consortia.support.BaseIT;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +50,8 @@ class SharingInstanceControllerIntegrationTests extends BaseIT {
   private ConsortiumRepository consortiumRepository;
   @MockBean
   private TenantRepository tenantRepository;
+  @MockBean
+  private ConsortiaConfigurationService configurationService;
   @MockBean
   private TenantService tenantService;
 
@@ -86,6 +89,7 @@ class SharingInstanceControllerIntegrationTests extends BaseIT {
   private void postAndVerifyResponseBody(String[][] instances) {
     for (String[] fields : instances) {
       // to skip the validation part
+      when(configurationService.getCentralTenantId(any())).thenReturn(TENANT);
       when(consortiumRepository.existsById(any())).thenReturn(true);
       when(tenantRepository.existsById(any())).thenReturn(true);
       when(tenantService.getCentralTenantId()).thenReturn(fields[2]);

--- a/src/test/java/org/folio/consortia/controller/SharingInstanceControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/SharingInstanceControllerTest.java
@@ -18,6 +18,7 @@ import org.folio.consortia.domain.dto.SharingInstance;
 import org.folio.consortia.repository.ConsortiumRepository;
 import org.folio.consortia.repository.SharingInstanceRepository;
 import org.folio.consortia.repository.TenantRepository;
+import org.folio.consortia.service.ConsortiaConfigurationService;
 import org.folio.consortia.service.SharingInstanceService;
 import org.folio.consortia.support.BaseIT;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,8 @@ class SharingInstanceControllerTest extends BaseIT {
   private ConsortiumRepository consortiumRepository;
   @MockBean
   private TenantRepository tenantRepository;
+  @MockBean
+  private ConsortiaConfigurationService configurationService;
 
   /* Success cases */
   @Test
@@ -65,6 +68,7 @@ class SharingInstanceControllerTest extends BaseIT {
     var headers = defaultHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
 
+    when(configurationService.getCentralTenantId(any())).thenReturn(TENANT);
     when(sharingInstanceService.start(any(), any())).thenReturn(sharingInstance);
 
     this.mockMvc.perform(


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-94
## Approach
Based on Foliojet team's request relate to permission issue with local tenant, All request for start sharing request go through central tenant 
We find central tenant of local tenant and move request to central tenant context 