### PR TITLE
MODCON-112 - Expand module permissions with permissions for sharing marc instances

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -272,7 +272,12 @@
           ],
           "modulePermissions": [
             "inventory.instances.item.get",
-            "inventory.instances.item.post"
+            "inventory.instances.item.post",
+            "change-manager.jobexecutions.post",
+            "change-manager.jobexecutions.put",
+            "change-manager.records.post",
+            "change-manager.jobexecutions.get",
+            "source-storage.records.delete"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -281,6 +281,7 @@
             "instance-authority-links.instances.collection.put",
             "instance-authority.linking-rules.collection.get",
             "inventory-storage.authorities.collection.get",
+            "inventory-storage.instances.item.get",
             "source-storage.records.delete"
           ]
         },
@@ -492,6 +493,7 @@
       "description": "Inventory: Share local instance with consortium",
       "subPermissions": [
         "consortia.sharing-instances.item.post",
+        "consortia.sharing-instances.item.get",
         "consortia.sharing-instances.collection.get"
       ],
       "visible": true

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -491,7 +491,8 @@
       "displayName": "Inventory: Share local instance with consortium",
       "description": "Inventory: Share local instance with consortium",
       "subPermissions": [
-        "consortia.sharing-instances.item.post"
+        "consortia.sharing-instances.item.post",
+        "consortia.sharing-instances.collection.get"
       ],
       "visible": true
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -273,10 +273,14 @@
           "modulePermissions": [
             "inventory.instances.item.get",
             "inventory.instances.item.post",
+            "change-manager.jobexecutions.get",
             "change-manager.jobexecutions.post",
             "change-manager.jobexecutions.put",
             "change-manager.records.post",
-            "change-manager.jobexecutions.get",
+            "instance-authority-links.instances.collection.get",
+            "instance-authority-links.instances.collection.put",
+            "instance-authority.linking-rules.collection.get",
+            "inventory-storage.authorities.collection.get",
             "source-storage.records.delete"
           ]
         },


### PR DESCRIPTION
## Purpose
to provide module permissions that are used during marc instance sharing process for the POST /consortia/{consortiumId}/sharing/instances endpoint. Besides, it's necessary to extend the permissions set for instance sharing to include permission that is required for polling the status of instance sharing process on UI.



## Learning
[MODCON-112](https://issues.folio.org/browse/MODCON-112)