### PR TITLE
MODCON-114. Secure setup of system users by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ requires and provides, the permissions, and the additional module metadata.
 | DB_USERNAME          |      folio_admin      | Postgres username                                                                                                                                           |
 | DB_PASSWORD          |           -           | Postgres username password                                                                                                                                  |
 | DB_DATABASE          |     okapi_modules     | Postgres database name                                                                                                                                      |
-| ENV                  |         folio         | Environment                                                                                                                                                 |
 | KAFKA_HOST           |         kafka         | Kafka broker hostname                                                                                                                                       |
 | KAFKA_PORT           |         9092          | Kafka broker port                                                                                                                                           |
 | ENV                  |         folio         | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed      |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ requires and provides, the permissions, and the additional module metadata.
 | KAFKA_PORT  |     9092      | Kafka broker port                                                                                                                                      |
 | ENV         |     folio     | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
 
+### System user configuration
+The module uses system user to communicate with other modules.
+For production deployments you MUST specify the password for this system user via env variable:
+`SYSTEM_USER_PASSWORD=<password>`.
+
 ## Additional information
 
 ### Issue tracker

--- a/README.md
+++ b/README.md
@@ -88,22 +88,19 @@ requires and provides, the permissions, and the additional module metadata.
 
 ### Environment variables
 
-| Name        | Default value | Description                                                                                                                                            |
-|:------------|:-------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DB_HOST     |   postgres    | Postgres hostname                                                                                                                                      |
-| DB_PORT     |     5432      | Postgres port                                                                                                                                          |
-| DB_USERNAME |  folio_admin  | Postgres username                                                                                                                                      |
-| DB_PASSWORD |       -       | Postgres username password                                                                                                                             |
-| DB_DATABASE | okapi_modules | Postgres database name                                                                                                                                 |
-| ENV         |     folio     | Environment                                                                                                                                            |
-| KAFKA_HOST  |     kafka     | Kafka broker hostname                                                                                                                                  |
-| KAFKA_PORT  |     9092      | Kafka broker port                                                                                                                                      |
-| ENV         |     folio     | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
-
-### System user configuration
-The module uses system user to communicate with other modules.
-For production deployments you MUST specify the password for this system user via env variable:
-`SYSTEM_USER_PASSWORD=<password>`.
+| Name                 |     Default value     | Description                                                                                                                                                 |
+|:---------------------|:---------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DB_HOST              |       postgres        | Postgres hostname                                                                                                                                           |
+| DB_PORT              |         5432          | Postgres port                                                                                                                                               |
+| DB_USERNAME          |      folio_admin      | Postgres username                                                                                                                                           |
+| DB_PASSWORD          |           -           | Postgres username password                                                                                                                                  |
+| DB_DATABASE          |     okapi_modules     | Postgres database name                                                                                                                                      |
+| ENV                  |         folio         | Environment                                                                                                                                                 |
+| KAFKA_HOST           |         kafka         | Kafka broker hostname                                                                                                                                       |
+| KAFKA_PORT           |         9092          | Kafka broker port                                                                                                                                           |
+| ENV                  |         folio         | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed      |
+| SYSTEM_USER_NAME     | consortia-system-user | Username of the system user                                                                                                                                 |
+| SYSTEM_USER_PASSWORD |           -           | Password of the system user                                                                                                                                 |
 
 ## Additional information
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -338,11 +338,12 @@
           "modulePermissions": [
             "users.collection.get",
             "users.item.post",
-            "users.item.put",
             "login.item.post",
+            "login.item.delete",
             "perms.users.get",
             "perms.users.item.post",
-            "perms.users.assign.immutable"
+            "perms.users.assign.immutable",
+            "perms.users.assign.mutable"
           ]
         },
         {

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <sharing_instances.yaml.file>${project.basedir}/src/main/resources/swagger.api/sharing_instances.yaml</sharing_instances.yaml.file>
     <sharing_settings.yaml.file>${project.basedir}/src/main/resources/swagger.api/sharing_settings.yaml</sharing_settings.yaml.file>
     <!-- runtime dependencies -->
-    <folio-spring-base.version>7.2.0</folio-spring-base.version>
+    <folio-spring-base.version>7.2.1</folio-spring-base.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>

--- a/src/main/java/org/folio/consortia/FolioConsortiaApplication.java
+++ b/src/main/java/org/folio/consortia/FolioConsortiaApplication.java
@@ -1,5 +1,6 @@
 package org.folio.consortia;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -8,7 +9,12 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @EnableFeignClients
 public class FolioConsortiaApplication {
 
+  public static final String SYSTEM_USER_PASSWORD = "SYSTEM_USER_PASSWORD";
+
   public static void main(String[] args) {
+    if (StringUtils.isEmpty(System.getenv(SYSTEM_USER_PASSWORD))) {
+      throw new IllegalArgumentException("Required environment variable is missing: " + SYSTEM_USER_PASSWORD);
+    }
     SpringApplication.run(FolioConsortiaApplication.class, args);
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,7 +62,7 @@ folio:
     validation:
       enabled: true
   system-user:
-    username: consortia-system-user
+    username: ${SYSTEM_USER_NAME:consortia-system-user}
     password: ${SYSTEM_USER_PASSWORD}
     lastname: SystemConsortia
     permissionsFilePath: permissions/system-user-permissions.csv


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-114

## Approach
Folio spring support has logic to reject system user without password and this fix applied into v7.2.1
https://github.com/folio-org/folio-spring-support/releases/tag/v7.2.1