### PR TITLE
[MODCON-118] Add sub permission to consortia.inventory.share.local.instance

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -282,7 +282,8 @@
             "instance-authority.linking-rules.collection.get",
             "inventory-storage.authorities.collection.get",
             "inventory-storage.instances.item.get",
-            "source-storage.records.delete"
+            "source-storage.records.delete",
+            "inventory-storage.instances.item.post"
           ]
         },
         {
@@ -495,7 +496,8 @@
       "subPermissions": [
         "consortia.sharing-instances.item.post",
         "consortia.sharing-instances.item.get",
-        "consortia.sharing-instances.collection.get"
+        "consortia.sharing-instances.collection.get",
+        "inventory-storage.authorities.collection.get"
       ],
       "visible": true
     },

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <sharing_instances.yaml.file>${project.basedir}/src/main/resources/swagger.api/sharing_instances.yaml</sharing_instances.yaml.file>
     <sharing_settings.yaml.file>${project.basedir}/src/main/resources/swagger.api/sharing_settings.yaml</sharing_settings.yaml.file>
     <!-- runtime dependencies -->
-    <folio-spring-base.version>7.2.1</folio-spring-base.version>
+    <folio-spring-base.version>7.2.2</folio-spring-base.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>


### PR DESCRIPTION
## Purpose
To be able to get information about linked MARC authority records when sharing local MARC instances it is needed to add inventory-storage.authorities.collection.get perm to sub-permissions for consortia.inventory.share.local.instance

## Approach
Add sub permission to consortia.inventory.share.local.instanceelopers *work* with your solution in the future.

