### PR TITLE
MODCON-132 - Provided module permission to ensure instance update during sharing marc instances

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -283,7 +283,8 @@
             "inventory-storage.authorities.collection.get",
             "inventory-storage.instances.item.get",
             "source-storage.records.delete",
-            "inventory-storage.instances.item.post"
+            "inventory-storage.instances.item.post",
+            "inventory-storage.instances.item.put"
           ]
         },
         {


### PR DESCRIPTION
## Purpose
to provide module permission to ensure instance update during instance sharing process for the POST /consortia/{consortiumId}/sharing/instances endpoint.


## Learning
[MODCON-132](https://issues.folio.org/browse/MODCON-132)