### PR TITLE
[MODCON-134] - Allow to re-share instance after first failed attempt

### DIFF
--- a/src/main/java/org/folio/consortia/repository/SharingInstanceRepository.java
+++ b/src/main/java/org/folio/consortia/repository/SharingInstanceRepository.java
@@ -11,12 +11,14 @@ import org.folio.consortia.domain.entity.SharingInstanceEntity;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SharingInstanceRepository extends JpaRepository<SharingInstanceEntity, UUID>, JpaSpecificationExecutor<SharingInstanceEntity> {
 
-  Optional<SharingInstanceEntity> findByInstanceIdAndSourceTenantIdAndTargetTenantId(UUID instanceIdentifier, String sourceTenantId, String targetTenantId);
+  @Query("SELECT si FROM SharingInstanceEntity si WHERE si.instanceId = ?1 AND si.sourceTenantId= ?2 AND si.targetTenantId= ?3")
+  Optional<SharingInstanceEntity> findByInstanceAndTenantIds(UUID instanceIdentifier, String sourceTenantId, String targetTenantId);
 
   interface Specifications {
     static Specification<SharingInstanceEntity> constructSpecification(UUID instanceIdentifier, String sourceTenantId,

--- a/src/main/java/org/folio/consortia/repository/SharingInstanceRepository.java
+++ b/src/main/java/org/folio/consortia/repository/SharingInstanceRepository.java
@@ -2,6 +2,7 @@ package org.folio.consortia.repository;
 
 import java.util.ArrayList;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SharingInstanceRepository extends JpaRepository<SharingInstanceEntity, UUID>, JpaSpecificationExecutor<SharingInstanceEntity> {
+
+  Optional<SharingInstanceEntity> findByInstanceIdAndSourceTenantIdAndTargetTenantId(UUID instanceIdentifier, String sourceTenantId, String targetTenantId);
 
   interface Specifications {
     static Specification<SharingInstanceEntity> constructSpecification(UUID instanceIdentifier, String sourceTenantId,

--- a/src/main/java/org/folio/consortia/service/impl/SharingInstanceServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SharingInstanceServiceImpl.java
@@ -114,8 +114,9 @@ public class SharingInstanceServiceImpl implements SharingInstanceService {
 
   /**
    * This method save sharing instance record to database.
-   * before to save sharing instance to db, previous attempt will be checked.
-   * if there is previous attempt, it will be updated with new attempt, otherwise created new record.
+   * Before to save sharing instance to db, previous attempt will be checked.
+   * If a matching previous attempt is found, the method updates it with the new attempt's error and status information.
+   * Otherwise, new record will be created.
    *
    * @param sharingInstance sharingInstanceDto
    * @return saved sharing instance entity
@@ -125,11 +126,11 @@ public class SharingInstanceServiceImpl implements SharingInstanceService {
       sharingInstance.getInstanceIdentifier(), sharingInstance.getSourceTenantId(), sharingInstance.getTargetTenantId());
 
     if (existingSharingInstanceOptional.isEmpty()) {
-      log.info("start:: There is no existing record, so creating new record");
+      log.info("saveSharingInstance:: There is no existing record, so creating new record");
       return sharingInstanceRepository.save(toEntity(sharingInstance));
     }
 
-    log.info("start:: Existed sharingInstance is being updated with new attempt with status={}", sharingInstance.getStatus());
+    log.info("saveSharingInstance:: Existed sharingInstance is being updated with new attempt with status={}", sharingInstance.getStatus());
     var existingSharingInstance = existingSharingInstanceOptional.get();
     existingSharingInstance.setError(sharingInstance.getError());
     existingSharingInstance.setStatus(sharingInstance.getStatus());

--- a/src/test/java/org/folio/consortia/service/SharingInstanceServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/SharingInstanceServiceTest.java
@@ -204,6 +204,47 @@ class SharingInstanceServiceTest {
   }
 
   @Test
+  void shouldUpdatePreviousSharingInstanceWhenAfterSuccessfulUpdate() throws JsonProcessingException {
+    String sourceTenantId = "mobius";
+    String targetTenantId = "college";
+    SharingInstance sharingInstance = createSharingInstance(instanceIdentifier, sourceTenantId, targetTenantId);
+    SharingInstanceEntity sharingInstanceEntity = new SharingInstanceEntity();
+    SharingInstanceEntity existingSharingInstanceEntity = createSharingInstanceEntity(sharingInstance.getId(), instanceIdentifier, sourceTenantId, targetTenantId);
+    SharingInstanceEntity updatingSharingInstanceEntity = createSharingInstanceEntity(sharingInstance.getId(), instanceIdentifier, sourceTenantId, targetTenantId);
+    updatingSharingInstanceEntity.setStatus(Status.COMPLETE);
+
+    // skip validation part
+    when(consortiumRepository.existsById(any())).thenReturn(true);
+    doNothing().when(tenantService).checkTenantExistsOrThrow(anyString());
+    when(folioExecutionContext.getOkapiHeaders()).thenReturn(headers);
+
+    when(tenantService.getCentralTenantId()).thenReturn("mobius");
+    when(conversionService.convert(any(), any())).thenReturn(toDto(sharingInstanceEntity));
+    when(sharingInstanceRepository.findByInstanceAndTenantIds(instanceIdentifier, sourceTenantId, targetTenantId))
+      .thenReturn(Optional.of(existingSharingInstanceEntity));
+
+    // existing object should be updated, not created new one
+    when(sharingInstanceRepository.save(updatingSharingInstanceEntity)).thenReturn(updatingSharingInstanceEntity);
+
+    // return instance as JsonNode when getting
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode inventoryInstance = objectMapper.readTree("{ \"source\" : \"folio\" } ");
+
+    when(inventoryService.getById(any())).thenReturn(inventoryInstance);
+
+    // do nothing when posting inventory instance
+    doNothing().when(inventoryService).saveInstance(anyString());
+
+    // verify status field gets updated and save() method gets called
+    sharingInstanceService.start(UUID.randomUUID(), sharingInstance);
+
+    assertThat(sharingInstance.getError()).isNull();
+    assertThat(sharingInstance.getStatus()).isEqualTo(Status.COMPLETE);
+    verify(sharingInstanceRepository, times(1)).save(any());
+    verify(sharingInstanceRepository, times(1)).findByInstanceAndTenantIds(any(), anyString(), anyString());
+  }
+
+  @Test
   void shouldPromoteSharingInstanceWithCompleteStatus() throws JsonProcessingException {
     SharingInstance sharingInstance = createSharingInstance(instanceIdentifier, "college", "mobius");
     SharingInstanceEntity sharingInstanceEntity = new SharingInstanceEntity();


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODCONSORTIA-01 Logging Improvement
  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema."
  instead, provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  the project reconstructs the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODCONSORTIA-01
 -->
https://issues.folio.org/browse/MODCON-134

## Purpose
Allowed to re-share instance in case of previous attempt failed. 
Existing sharing instance record will be updated with new attempt details