### PR TITLE
MODCONSKC-10. Add support of TLS when  connecting to MSK

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,19 +88,24 @@ requires and provides, the permissions, and the additional module metadata.
 
 ### Environment variables
 
-| Name                 |     Default value     | Description                                                                                                                                            |
-|:---------------------|:---------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DB_HOST              |       postgres        | Postgres hostname                                                                                                                                      |
-| DB_PORT              |         5432          | Postgres port                                                                                                                                          |
-| DB_USERNAME          |      folio_admin      | Postgres username                                                                                                                                      |
-| DB_PASSWORD          |           -           | Postgres username password                                                                                                                             |
-| DB_DATABASE          |     okapi_modules     | Postgres database name                                                                                                                                 |
-| KAFKA_HOST           |         kafka         | Kafka broker hostname                                                                                                                                  |
-| KAFKA_PORT           |         9092          | Kafka broker port                                                                                                                                      |
-| ENV                  |         folio         | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
-| OKAPI_URL            |   http://okapi:9130   | Okapi url                                                                                                                                              |
-| SYSTEM_USER_NAME     | consortia-system-user | Username of the system user                                                                                                                            |
-| SYSTEM_USER_PASSWORD |           -           | Password of the system user                                                                                                                            |
+| Name                          |     Default value     | Description                                                                                                                                                |
+|:------------------------------|:---------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DB_HOST                       |       postgres        | Postgres hostname                                                                                                                                          |
+| DB_PORT                       |         5432          | Postgres port                                                                                                                                              |
+| DB_USERNAME                   |      folio_admin      | Postgres username                                                                                                                                          |
+| DB_PASSWORD                   |           -           | Postgres username password                                                                                                                                 |
+| DB_DATABASE                   |     okapi_modules     | Postgres database name                                                                                                                                     |
+| KAFKA_HOST                    |         kafka         | Kafka broker hostname                                                                                                                                      |
+| KAFKA_PORT                    |         9092          | Kafka broker port                                                                                                                                          |
+| KAFKA_SECURITY_PROTOCOL       |       PLAINTEXT       | Kafka security protocol used to communicate with brokers (SSL or PLAINTEXT)                                                                                |
+| KAFKA_SSL_KEYSTORE_LOCATION   |           -           | The location of the Kafka key store file. This is optional for client and can be used for two-way authentication for client.                               |
+| KAFKA_SSL_KEYSTORE_PASSWORD   |           -           | The store password for the Kafka key store file. This is optional for client and only needed if 'ssl.keystore.location' is configured.                     |
+| KAFKA_SSL_TRUSTSTORE_LOCATION |           -           | The location of the Kafka trust store file.                                                                                                                |
+| KAFKA_SSL_TRUSTSTORE_PASSWORD |           -           | The password for the Kafka trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. |
+| ENV                           |         folio         | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed     |
+| OKAPI_URL                     |   http://okapi:9130   | Okapi url                                                                                                                                                  |
+| SYSTEM_USER_NAME              | consortia-system-user | Username of the system user                                                                                                                                |
+| SYSTEM_USER_PASSWORD          |           -           | Password of the system user                                                                                                                                |
 
 ## Additional information
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -589,6 +589,26 @@
         "value": "9092"
       },
       {
+        "name": "KAFKA_SECURITY_PROTOCOL",
+        "value": "PLAINTEXT"
+      },
+      {
+        "name": "KAFKA_SSL_KEYSTORE_LOCATION",
+        "value": ""
+      },
+      {
+        "name": "KAFKA_SSL_KEYSTORE_PASSWORD",
+        "value": ""
+      },
+      {
+        "name": "KAFKA_SSL_TRUSTSTORE_LOCATION",
+        "value": ""
+      },
+      {
+        "name": "KAFKA_SSL_TRUSTSTORE_PASSWORD",
+        "value": ""
+      },
+      {
         "name": "OKAPI_URL",
         "value": "http://okapi:9130"
       },

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,13 @@ spring:
     url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_DATABASE:okapi_modules}
   kafka:
     bootstrap-servers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
+    security:
+      protocol: ${KAFKA_SECURITY_PROTOCOL:PLAINTEXT}
+    ssl:
+      key-store-password: ${KAFKA_SSL_KEYSTORE_PASSWORD:}
+      key-store-location: ${KAFKA_SSL_KEYSTORE_LOCATION:}
+      trust-store-password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
+      trust-store-location: ${KAFKA_SSL_TRUSTSTORE_LOCATION:}
   sql:
     init:
       continue-on-error: true


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODCONSKC-10
TLS configuration now is supported, approach is the same as in corresponding PR in mod-search:
https://github.com/folio-org/mod-search/pull/92/files