### PR TITLE
MODCON-157: testcontainers.kafka.KafkaContainer, apache/kafka-native

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,8 @@
 
     <!-- test dependencies -->
     <wiremock-standalone.version>3.0.1</wiremock-standalone.version>
-    <testcontainers.version>1.19.3</testcontainers.version>
+    <testcontainers.version>1.20.1</testcontainers.version>
     <snakeyaml.version>2.2</snakeyaml.version>
-    <testcontainers-bom.version>1.19.3</testcontainers-bom.version>
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
   </properties>
 
@@ -70,7 +69,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>${testcontainers-bom.version}</version>
+        <version>${testcontainers.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -204,13 +203,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/folio/consortia/support/extension/impl/KafkaContainerExtension.java
+++ b/src/test/java/org/folio/consortia/support/extension/impl/KafkaContainerExtension.java
@@ -5,12 +5,12 @@ import static org.testcontainers.utility.DockerImageName.parse;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class KafkaContainerExtension implements BeforeAllCallback, AfterAllCallback {
   private static final String SPRING_PROPERTY_NAME = "spring.kafka.bootstrap-servers";
-  private static final DockerImageName KAFKA_IMAGE = parse("confluentinc/cp-kafka:7.0.3");
+  private static final DockerImageName KAFKA_IMAGE = parse("apache/kafka-native:3.8.0");
   private static final KafkaContainer CONTAINER = new KafkaContainer(KAFKA_IMAGE)
     .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODCON-157

Upgrade from deprecated org.testcontainers.containers.KafkaContainer to org.testcontainers.kafka.KafkaContainer, see
https://java.testcontainers.org/modules/kafka/

Upgrade from confluentinc/cp-kafka:7.0.3 to apache/kafka-native:3.8.0, see
https://hub.docker.com/r/apache/kafka-native

## Purpose
Replace the deprecated KafkaContainer. Replace the heavy-weight confluentinc/cp-kafka container.
https://folio-org.atlassian.net/browse/MODCON-157

## Approach
Bump testcontainers from 1.19.3 to 1.20.1.
Use new KafkaContainer.
Use apache/kafka-native.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.