### PR TITLE
[MODCON-164] Update libraries of dependant acq modules to the latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.3.4</version>
     <relativePath />
   </parent>
 
@@ -43,25 +43,26 @@
     <publish_coordinator.yaml.file>${project.basedir}/src/main/resources/swagger.api/publications.yaml</publish_coordinator.yaml.file>
     <sharing_instances.yaml.file>${project.basedir}/src/main/resources/swagger.api/sharing_instances.yaml</sharing_instances.yaml.file>
     <sharing_settings.yaml.file>${project.basedir}/src/main/resources/swagger.api/sharing_settings.yaml</sharing_settings.yaml.file>
+
     <!-- runtime dependencies -->
-    <folio-spring-base.version>8.1.0</folio-spring-base.version>
-    <folio-service-tools.version>4.0.0</folio-service-tools.version>
-    <mapstruct.version>1.5.3.Final</mapstruct.version>
+    <folio-spring-base.version>8.2.0</folio-spring-base.version>
+    <folio-service-tools.version>4.0.1</folio-service-tools.version>
+    <mapstruct.version>1.6.2</mapstruct.version>
 
     <!--Maven plugin dependencies-->
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
-    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
-    <openapi-generator.version>7.3.0</openapi-generator.version>
-    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-    <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
+    <openapi-generator.version>7.9.0</openapi-generator.version>
+    <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
+    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
 
     <!-- test dependencies -->
     <wiremock-standalone.version>3.0.1</wiremock-standalone.version>
-    <testcontainers.version>1.20.1</testcontainers.version>
-    <snakeyaml.version>2.2</snakeyaml.version>
-    <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+    <testcontainers.version>1.20.2</testcontainers.version>
+    <snakeyaml.version>2.3</snakeyaml.version>
+    <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -124,7 +125,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>3.0.0</version>
+      <version>4.2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -164,7 +165,7 @@
     <dependency>
       <groupId>one.util</groupId>
       <artifactId>streamex</artifactId>
-      <version>0.8.1</version>
+      <version>0.8.3</version>
     </dependency>
     <dependency>
       <groupId>org.mapstruct</groupId>
@@ -574,7 +575,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>enforce-maven</id>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
 
+    <!--Folio dependencies properties-->
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
+
     <!-- test dependencies -->
     <wiremock-standalone.version>3.0.1</wiremock-standalone.version>
     <testcontainers.version>1.20.2</testcontainers.version>
@@ -593,6 +596,18 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## Purpose
[[MODCON-164] Update libraries of dependant acq modules to the latest versions
](https://folio-org.atlassian.net/browse/MODCON-164)

## Approach
- Update versions
- Add module descriptor validator