### PR TITLE
MODINV-1116 ECS | User with "Share" permission cannot share "Local" MARC bib record from member tenant

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -276,7 +276,7 @@
             "change-manager.jobExecutions.item.get",
             "change-manager.jobExecutions.children.collection.get",
             "change-manager.jobexecutions.post",
-            "change-manager.jobExecutions.item.put",
+            "change-manager.jobExecutions.jobProfile.item.put",
             "change-manager.records.post",
             "instance-authority-links.instances.collection.get",
             "instance-authority-links.instances.collection.put",


### PR DESCRIPTION
## Purpose
[MODINV-1116](https://folio-org.atlassian.net/browse/MODINV-1116) ECS | User with "Share" permission cannot share "Local" MARC bib record from member tenant

## Approach
update invalid module permission
