### PR TITLE
MODCON-174 - Expand module permissions with permission for sharing marc instances

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -284,6 +284,7 @@
             "inventory-storage.authorities.collection.get",
             "inventory-storage.instances.item.get",
             "source-storage.records.delete",
+            "source-storage.records.update",
             "inventory-storage.instances.item.post",
             "inventory-storage.instances.item.put"
           ]


### PR DESCRIPTION
## Purpose
to provide module permission that is required during marc instance sharing process for updating suppressFromDiscovery field of marc record.

## Learning
[MODCON-174](https://folio-org.atlassian.net/browse/MODCON-174)
