### PR TITLE
[MODCONSKC-61] ECS | Update Member tenant user email value on Central tenant

### DIFF
--- a/src/main/java/org/folio/consortia/service/UserTenantService.java
+++ b/src/main/java/org/folio/consortia/service/UserTenantService.java
@@ -102,12 +102,12 @@ public interface UserTenantService {
   void deleteByUserIdAndTenantId(UUID consortiumId, String tenantId, UUID userId);
 
   /**
-   * Update the firstname and the lastname of shadows users in all tenants except tenant where user was originally created.
+   * Update the first and last name and the email of the shadow user in all tenants except tenant where user was originally created.
    *
    * @param userId           id of user
    * @param originalTenantId tenant id where real user was created
    */
-  void updateShadowUsersFirstAndLastNames(UUID userId, String originalTenantId);
+  void updateShadowUsersNameAndEmail(UUID userId, String originalTenantId);
 
   /**
    * Check if user has primary affiliation.

--- a/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
@@ -108,7 +108,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
       }
 
       if (Boolean.TRUE.equals(userEvent.getIsPersonalDataChanged())) {
-        userTenantService.updateShadowUsersFirstAndLastNames(getUserId(userEvent), userEvent.getTenantId());
+        userTenantService.updateShadowUsersNameAndEmail(getUserId(userEvent), userEvent.getTenantId());
       }
       PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId, null);
       String data = objectMapper.writeValueAsString(affiliationEvent);

--- a/src/main/java/org/folio/consortia/service/impl/UserTenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserTenantServiceImpl.java
@@ -208,16 +208,18 @@ public class UserTenantServiceImpl implements UserTenantService {
   }
 
   @Override
-  public void updateShadowUsersFirstAndLastNames(UUID userId, String originalTenantId) {
+  public void updateShadowUsersNameAndEmail(UUID userId, String originalTenantId) {
     List<UserTenantEntity> userTenantEntities = userTenantRepository.getByUserIdAndIsPrimaryFalse(userId);
     if (CollectionUtils.isNotEmpty(userTenantEntities)) {
       String firstName;
       String lastName;
+      String email;
       List<String> tenantIds;
       try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(originalTenantId, folioModuleMetadata, folioExecutionContext))) {
         User primaryUser = userService.getById(userId);
         firstName = primaryUser.getPersonal().getFirstName();
         lastName = primaryUser.getPersonal().getLastName();
+        email = primaryUser.getPersonal().getEmail();
         tenantIds = userTenantEntities.stream().map(userTenantEntity -> userTenantEntity.getTenant().getId()).toList();
       }
       log.info("Updating shadow users in all tenants exist in consortia for the user: {}", userId);
@@ -226,6 +228,7 @@ public class UserTenantServiceImpl implements UserTenantService {
           User shadowUser = userService.getById(userId);
           shadowUser.getPersonal().setFirstName(firstName);
           shadowUser.getPersonal().setLastName(lastName);
+          shadowUser.getPersonal().setEmail(email);
           userService.updateUser(shadowUser);
           log.info("Updated shadow user: {} in tenant : {}", userId, tenantId);
         }

--- a/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
@@ -206,7 +206,7 @@ class UserTenantServiceTest {
   }
 
   @Test
-  void shouldUpdateFirstAndLastNames() {
+  void shouldUpdateEmailAndName() {
     UUID userId = UUID.fromString(RANDOM_USER_ID);
     String tenantId = "diku";
     UUID associationId = UUID.randomUUID();
@@ -214,6 +214,7 @@ class UserTenantServiceTest {
     User shadowUser = createUserEntity(userId);
     shadowUser.getPersonal().setFirstName("notUpdatedFirstName");
     shadowUser.getPersonal().setFirstName("notUpdatedLastName");
+    shadowUser.getPersonal().setEmail("notUpdatedEmail");
     User updatedShadowUser = createUserEntity(userId);
     UserTenantEntity userTenant = createUserTenantEntity(associationId, userId, "user", "shadowTenantId");
     userTenant.setIsPrimary(false);
@@ -227,7 +228,7 @@ class UserTenantServiceTest {
     // In first call it return primary User, in second call it return shadow user.
     when(userService.getById(userId)).thenReturn(primaryUser).thenReturn(shadowUser);
     doNothing().when(userService).updateUser(updatedShadowUser);
-    userTenantService.updateShadowUsersFirstAndLastNames(userId, tenantId);
+    userTenantService.updateShadowUsersNameAndEmail(userId, tenantId);
 
     verify(userService, times(2)).getById(userId);
     verify(userService, times(1)).updateUser(updatedShadowUser);
@@ -246,7 +247,7 @@ class UserTenantServiceTest {
 
     // Returned object when expected parameter passed
     when(userTenantRepository.getByUserIdAndIsPrimaryFalse(userId)).thenReturn(emptyListOfUserTenantEntities);
-    userTenantService.updateShadowUsersFirstAndLastNames(userId, tenantId);
+    userTenantService.updateShadowUsersNameAndEmail(userId, tenantId);
 
     verify(userService, times(0)).updateUser(any());
     verify(userService, times(0)).getById(any());


### PR DESCRIPTION
## Purpose
[[MODCONSKC-61] ECS | Update Member tenant user email value on Central tenant](https://folio-org.atlassian.net/browse/MODCONSKC-61)

## Approach
- Sync email and name update for users if personal data was changed